### PR TITLE
Fix issue 16

### DIFF
--- a/uci/engine_provider.py
+++ b/uci/engine_provider.py
@@ -30,9 +30,9 @@ class EngineProvider(object):
         cls.modern_engines: List[Dict[str, str]] = read_engine_ini(filename='engines.ini')
         cls.retro_engines: List[Dict[str, str]] = read_engine_ini(filename='retro.ini')
         cls.favorite_engines: List[Dict[str, str]] = read_engine_ini(filename='favorites.ini')
-        cls.installed_engines: List[Dict[str, str]] = cls.modern_engines + cls.retro_engines + cls.favorite_engines
         # set retro/favorite engines to the list of modern engines in case retro.ini or favorites.ini is empty
         if not cls.retro_engines:
             cls.retro_engines = cls.modern_engines
         if not cls.favorite_engines:
             cls.favorite_engines = cls.modern_engines
+        cls.installed_engines: List[Dict[str, str]] = cls.modern_engines + cls.retro_engines + cls.favorite_engines


### PR DESCRIPTION
The repository only contains 3 modern chess engines and no retro.ini and favorites.ini files. From before there was code that then added the 3 modern engines to retro and favorites but it was done without makine the installed_engines also grow from 3 to 9.

this is the simplest possible fix, moved the line that creates the engine list to after the lines that makes these adds, tested both with these ini files and without