### PR TITLE
Issue20

### DIFF
--- a/picochess.py
+++ b/picochess.py
@@ -809,7 +809,7 @@ async def main() -> None:
             my_dgtpi = DgtPi(dgtboard, main_loop)
             dgtdispatcher.register("i2c")
             asyncio.create_task(my_dgtpi.dgt_consumer())
-            await asyncio.to_thread(asyncio.run, my_dgtpi.process_incoming_clock_forever())
+            asyncio.create_task(my_dgtpi.process_incoming_clock_forever())
         else:
             logger.debug("(ser) starting the board connection")
             dgtboard.run()  # a clock can only be online together with the board, so we must start it infront

--- a/picochess.py
+++ b/picochess.py
@@ -809,7 +809,7 @@ async def main() -> None:
             my_dgtpi = DgtPi(dgtboard, main_loop)
             dgtdispatcher.register("i2c")
             asyncio.create_task(my_dgtpi.dgt_consumer())
-            asyncio.to_thread(asyncio.run, my_dgtpi.process_incoming_clock_forever())
+            await asyncio.to_thread(asyncio.run, my_dgtpi.process_incoming_clock_forever())
         else:
             logger.debug("(ser) starting the board connection")
             dgtboard.run()  # a clock can only be online together with the board, so we must start it infront


### PR DESCRIPTION
Async architecture change to remove most threads made the DGTPI 3000 stop working.
The async function that was supposed to poll the buttons died due wrong way to start it as thread.
Now starting it as an async task.

So this is one line change.

I tested on my DGT PI 3000, and it did not work before this change, and worked after this change.