### PR TITLE
106 update and git status to menu - AND do not update engine folder

### DIFF
--- a/check-git-status.sh
+++ b/check-git-status.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Compact git status for /opt/picochess (max 11 chars)
+
+REPO_DIR="/opt/picochess"
+
+if [ ! -d "$REPO_DIR/.git" ]; then
+    echo "git:none"
+    exit 0
+fi
+
+cd "$REPO_DIR" || exit 1
+
+# Tag?
+TAG=$(git describe --tags --exact-match 2>/dev/null)
+if [ -n "$TAG" ]; then
+    echo "git:$TAG" | cut -c1-11
+    exit 0
+fi
+
+# Branch or commit
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+if [ "$BRANCH" = "HEAD" ]; then
+    COMMIT=$(git rev-parse --short HEAD 2>/dev/null)
+    echo "git:$COMMIT" | cut -c1-11
+else
+    echo "git:$BRANCH" | cut -c1-11
+fi
+exit 0

--- a/check-update-status.sh
+++ b/check-update-status.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+SERVICE="picochess-update.service"
+TIMESTAMP_FILE="/var/log/picochess-last-update"
+
+# 1. Check if last run failed
+if systemctl is-failed --quiet "$SERVICE"; then
+    echo "upd: failed"
+    exit 0
+fi
+
+# 2. If no successful run ever
+if [ ! -s "$TIMESTAMP_FILE" ]; then
+    echo "upd: never"
+    exit 0
+fi
+
+# 3. Calculate age in days
+NOW=$(date +%s)
+LAST_RUN=$(cat "$TIMESTAMP_FILE")
+AGE=$(( (NOW - LAST_RUN) / 86400 ))
+
+if [ "$AGE" -gt 999 ]; then
+    echo "upd: long ago"
+else
+    echo "upd: ${AGE}d ago"
+fi
+exit 0

--- a/dgt/menu.py
+++ b/dgt/menu.py
@@ -148,8 +148,9 @@ class MenuState(object):
     SYS_INFO = 710000
     SYS_INFO_VERS = 710100
     SYS_INFO_UPDATED = 710200
-    SYS_INFO_IP = 710300
-    SYS_INFO_BATTERY = 710400
+    SYS_INFO_GIT = 710300
+    SYS_INFO_IP = 710400
+    SYS_INFO_BATTERY = 710500
     SYS_SOUND = 720000
     SYS_SOUND_BEEP = 721000  # never, always, some
     SYS_LANG = 730000
@@ -1548,6 +1549,12 @@ class DgtMenu(object):
         text = self.dgttranslate.text(self.menu_system_info.value)
         return text
 
+    def enter_sys_info_git_menu(self):
+        """Set the menu state."""
+        self.state = MenuState.SYS_INFO_GIT
+        text = self.dgttranslate.text(self.menu_system_info.value)
+        return text
+
     def enter_sys_info_ip_menu(self):
         """Set the menu state."""
         self.state = MenuState.SYS_INFO_IP
@@ -1991,6 +1998,9 @@ class DgtMenu(object):
             text = self.enter_sys_info_menu()
 
         elif self.state == MenuState.SYS_INFO_UPDATED:
+            text = self.enter_sys_info_menu()
+
+        elif self.state == MenuState.SYS_INFO_GIT:
             text = self.enter_sys_info_menu()
 
         elif self.state == MenuState.SYS_INFO_IP:
@@ -2843,6 +2853,8 @@ class DgtMenu(object):
                 text = self.enter_sys_info_vers_menu()
             if self.menu_system_info == Info.UPDATED:
                 text = self.enter_sys_info_updated_menu()
+            if self.menu_system_info == Info.GIT:
+                text = self.enter_sys_info_git_menu()
             if self.menu_system_info == Info.IPADR:
                 text = self.enter_sys_info_ip_menu()
             if self.menu_system_info == Info.BATTERY:
@@ -2856,6 +2868,12 @@ class DgtMenu(object):
 
         elif self.state == MenuState.SYS_INFO_UPDATED:
             text = self.dgttranslate.text("B10_pico_updated_status")
+            text.rd = ClockIcons.DOT
+            text.wait = False
+            text = await self._fire_dispatchdgt(text)
+
+        elif self.state == MenuState.SYS_INFO_GIT:
+            text = self.dgttranslate.text("B10_pico_git_status")
             text.rd = ClockIcons.DOT
             text.wait = False
             text = await self._fire_dispatchdgt(text)
@@ -3568,8 +3586,13 @@ class DgtMenu(object):
             self.menu_system_info = InfoLoop.prev(self.menu_system_info)
             text = self.dgttranslate.text(self.menu_system_info.value)
 
-        elif self.state == MenuState.SYS_INFO_IP:
+        elif self.state == MenuState.SYS_INFO_GIT:
             self.state = MenuState.SYS_INFO_UPDATED
+            self.menu_system_info = InfoLoop.prev(self.menu_system_info)
+            text = self.dgttranslate.text(self.menu_system_info.value)
+
+        elif self.state == MenuState.SYS_INFO_IP:
+            self.state = MenuState.SYS_INFO_GIT
             self.menu_system_info = InfoLoop.prev(self.menu_system_info)
             text = self.dgttranslate.text(self.menu_system_info.value)
 
@@ -4189,6 +4212,11 @@ class DgtMenu(object):
             text = self.dgttranslate.text(self.menu_system_info.value)
 
         elif self.state == MenuState.SYS_INFO_UPDATED:
+            self.state = MenuState.SYS_INFO_GIT
+            self.menu_system_info = InfoLoop.next(self.menu_system_info)
+            text = self.dgttranslate.text(self.menu_system_info.value)
+
+        elif self.state == MenuState.SYS_INFO_GIT:
             self.state = MenuState.SYS_INFO_IP
             self.menu_system_info = InfoLoop.next(self.menu_system_info)
             text = self.dgttranslate.text(self.menu_system_info.value)

--- a/dgt/menu.py
+++ b/dgt/menu.py
@@ -146,9 +146,10 @@ class MenuState(object):
     SYS_POWER_RESTART = 705300
     SYS_POWER_UPDATE = 705400
     SYS_INFO = 710000
-    SYS_INFO_VERS = 711000
-    SYS_INFO_IP = 712000
-    SYS_INFO_BATTERY = 713000
+    SYS_INFO_VERS = 710100
+    SYS_INFO_UPDATED = 710200
+    SYS_INFO_IP = 710300
+    SYS_INFO_BATTERY = 710400
     SYS_SOUND = 720000
     SYS_SOUND_BEEP = 721000  # never, always, some
     SYS_LANG = 730000
@@ -1541,6 +1542,12 @@ class DgtMenu(object):
         text = self.dgttranslate.text(self.menu_system_info.value)
         return text
 
+    def enter_sys_info_updated_menu(self):
+        """Set the menu state."""
+        self.state = MenuState.SYS_INFO_UPDATED
+        text = self.dgttranslate.text(self.menu_system_info.value)
+        return text
+
     def enter_sys_info_ip_menu(self):
         """Set the menu state."""
         self.state = MenuState.SYS_INFO_IP
@@ -1981,6 +1988,9 @@ class DgtMenu(object):
             text = self.enter_sys_menu()
 
         elif self.state == MenuState.SYS_INFO_VERS:
+            text = self.enter_sys_info_menu()
+
+        elif self.state == MenuState.SYS_INFO_UPDATED:
             text = self.enter_sys_info_menu()
 
         elif self.state == MenuState.SYS_INFO_IP:
@@ -2831,6 +2841,8 @@ class DgtMenu(object):
         elif self.state == MenuState.SYS_INFO:
             if self.menu_system_info == Info.VERSION:
                 text = self.enter_sys_info_vers_menu()
+            if self.menu_system_info == Info.UPDATED:
+                text = self.enter_sys_info_updated_menu()
             if self.menu_system_info == Info.IPADR:
                 text = self.enter_sys_info_ip_menu()
             if self.menu_system_info == Info.BATTERY:
@@ -2838,6 +2850,12 @@ class DgtMenu(object):
 
         elif self.state == MenuState.SYS_INFO_VERS:
             text = self.dgttranslate.text("B10_picochess")
+            text.rd = ClockIcons.DOT
+            text.wait = False
+            text = await self._fire_dispatchdgt(text)
+
+        elif self.state == MenuState.SYS_INFO_UPDATED:
+            text = self.dgttranslate.text("B10_pico_updated_status")
             text.rd = ClockIcons.DOT
             text.wait = False
             text = await self._fire_dispatchdgt(text)
@@ -3545,8 +3563,13 @@ class DgtMenu(object):
             self.menu_system_info = InfoLoop.prev(self.menu_system_info)
             text = self.dgttranslate.text(self.menu_system_info.value)
 
-        elif self.state == MenuState.SYS_INFO_IP:
+        elif self.state == MenuState.SYS_INFO_UPDATED:
             self.state = MenuState.SYS_INFO_VERS
+            self.menu_system_info = InfoLoop.prev(self.menu_system_info)
+            text = self.dgttranslate.text(self.menu_system_info.value)
+
+        elif self.state == MenuState.SYS_INFO_IP:
+            self.state = MenuState.SYS_INFO_UPDATED
             self.menu_system_info = InfoLoop.prev(self.menu_system_info)
             text = self.dgttranslate.text(self.menu_system_info.value)
 
@@ -4161,6 +4184,11 @@ class DgtMenu(object):
             text = self.dgttranslate.text(self.menu_system.value)
 
         elif self.state == MenuState.SYS_INFO_VERS:
+            self.state = MenuState.SYS_INFO_UPDATED
+            self.menu_system_info = InfoLoop.next(self.menu_system_info)
+            text = self.dgttranslate.text(self.menu_system_info.value)
+
+        elif self.state == MenuState.SYS_INFO_UPDATED:
             self.state = MenuState.SYS_INFO_IP
             self.menu_system_info = InfoLoop.next(self.menu_system_info)
             text = self.dgttranslate.text(self.menu_system_info.value)

--- a/dgt/translate.py
+++ b/dgt/translate.py
@@ -1770,6 +1770,15 @@ class DgtTranslate(object):
                 small_text=f"{self.update_status}",
             )
             detxt = nltxt = frtxt = estxt = ittxt = entxt
+        if text_id == "pico_git_status":
+            wait = True
+            entxt = Dgt.DISPLAY_TEXT(
+                web_text=f"{self.git_status}",
+                large_text=f"{self.git_status}",
+                medium_text=f"{self.git_status}",
+                small_text=f"{self.git_status}",
+            )
+            detxt = nltxt = frtxt = estxt = ittxt = entxt
         if text_id == "nofunction":
             entxt = Dgt.DISPLAY_TEXT(
                 web_text="",
@@ -5098,6 +5107,14 @@ class DgtTranslate(object):
                 large_text="Update info",
                 medium_text="Upd info",
                 small_text="Upd",
+            )
+            detxt = nltxt = frtxt = estxt = ittxt = entxt
+        if text_id == "info_git_menu":
+            entxt = Dgt.DISPLAY_TEXT(
+                web_text="git info",
+                large_text="git info",
+                medium_text="git info",
+                small_text="git",
             )
             detxt = nltxt = frtxt = estxt = ittxt = entxt
         if text_id == "info_ipadr_menu":

--- a/dgt/translate.py
+++ b/dgt/translate.py
@@ -48,12 +48,18 @@ class DgtTranslate(object):
         self.version_large = self.version_large.replace(".", "")
         self.capital = False  # Set from dgt.menu lateron
         self.notation = False  # Set from dgt.menu lateron
-        self.update_status = "upd unknown"
+        self.update_status = "no info"
+        self.git_status = "no info"
 
     def set_last_updated_info(self, update_status: str):
         """Set last update status info string."""
         if update_status:
             self.update_status = update_status
+
+    def set_git_info(self, git_status: str):
+        """Set last update status info string."""
+        if git_status:
+            self.git_status = git_status
 
     def beep_to_config(self, beep: Beep):
         """Transfer beep to dict."""

--- a/dgt/translate.py
+++ b/dgt/translate.py
@@ -48,6 +48,12 @@ class DgtTranslate(object):
         self.version_large = self.version_large.replace(".", "")
         self.capital = False  # Set from dgt.menu lateron
         self.notation = False  # Set from dgt.menu lateron
+        self.update_status = "upd unknown"
+
+    def set_last_updated_info(self, update_status: str):
+        """Set last update status info string."""
+        if update_status:
+            self.update_status = update_status
 
     def beep_to_config(self, beep: Beep):
         """Transfer beep to dict."""
@@ -1749,6 +1755,15 @@ class DgtTranslate(object):
             frtxt = entxt
             estxt = entxt
             ittxt = entxt
+        if text_id == "pico_updated_status":
+            wait = True
+            entxt = Dgt.DISPLAY_TEXT(
+                web_text=f"{self.update_status}",
+                large_text=f"{self.update_status}",
+                medium_text=f"{self.update_status}",
+                small_text=f"{self.update_status}",
+            )
+            detxt = nltxt = frtxt = estxt = ittxt = entxt
         if text_id == "nofunction":
             entxt = Dgt.DISPLAY_TEXT(
                 web_text="",
@@ -5071,6 +5086,14 @@ class DgtTranslate(object):
                 medium_text="Versione",
                 small_text="versio",
             )
+        if text_id == "info_updated_menu":
+            entxt = Dgt.DISPLAY_TEXT(
+                web_text="Update info",
+                large_text="Update info",
+                medium_text="Upd info",
+                small_text="Upd",
+            )
+            detxt = nltxt = frtxt = estxt = ittxt = entxt
         if text_id == "info_ipadr_menu":
             entxt = Dgt.DISPLAY_TEXT(
                 web_text="",
@@ -7714,12 +7737,7 @@ class DgtTranslate(object):
                 medium_text="Aggiorna",  # 8
                 small_text="Agg",  # 3
             )
-            detxt = Dgt.DISPLAY_TEXT(
-                web_text="Neu starten und aktualisieren Pico",  # 33
-                large_text="Aktualis",  # 9
-                medium_text="Update",  # 6
-                small_text="Upd",  # 3
-            )
+            detxt = entxt
             nltxt = Dgt.DISPLAY_TEXT(
                 web_text="Opnieuw opstarten en bijwerken",  # 32
                 large_text="Bijwerken",  # 9

--- a/dgt/util.py
+++ b/dgt/util.py
@@ -601,12 +601,13 @@ class Info(MyEnum):
 
     VERSION = "B00_info_version_menu"
     UPDATED = "B00_info_updated_menu"
+    GIT = "B00_info_git_menu"
     IPADR = "B00_info_ipadr_menu"
     BATTERY = "B00_info_battery_menu"
 
     @classmethod
     def items(cls):
-        return [Info.VERSION, Info.UPDATED, Info.IPADR, Info.BATTERY]
+        return [Info.VERSION, Info.UPDATED, Info.GIT, Info.IPADR, Info.BATTERY]
 
 
 class InfoLoop(object):

--- a/dgt/util.py
+++ b/dgt/util.py
@@ -600,12 +600,13 @@ class Info(MyEnum):
     """Info Class."""
 
     VERSION = "B00_info_version_menu"
+    UPDATED = "B00_info_updated_menu"
     IPADR = "B00_info_ipadr_menu"
     BATTERY = "B00_info_battery_menu"
 
     @classmethod
     def items(cls):
-        return [Info.VERSION, Info.IPADR, Info.BATTERY]
+        return [Info.VERSION, Info.UPDATED, Info.IPADR, Info.BATTERY]
 
 
 class InfoLoop(object):

--- a/install-picochess.sh
+++ b/install-picochess.sh
@@ -245,6 +245,7 @@ cp etc/picochess-update.service /etc/systemd/system/
 cp etc/run-picochess-if-flagged.sh /usr/local/bin/
 chmod +x /usr/local/bin/run-picochess-if-flagged.sh
 chmod +x /opt/picochess/check-update-status.sh
+chmod +x /opt/picochess/check-git-status.sh
 touch /var/log/picochess-update.log /var/log/picochess-last-update
 chown root:root /var/log/picochess-*
 systemctl daemon-reload

--- a/install-picochess.sh
+++ b/install-picochess.sh
@@ -127,6 +127,12 @@ echo " ------- "
 if [ -d "/opt/picochess/.git" ]; then
     echo "picochess git repo already exists, updating code..."
     cd /opt/picochess
+    # === Protect all files under engines/ from being touched by update git reset ===
+    # engine files will be moved to engine-examples and only copied for new clones
+    if [ -d engines ]; then
+        echo "Marking engines/ files as skip-worktree to protect local engines..."
+        find engines -type f -print0 | xargs -0 sudo -u pi git update-index --skip-worktree
+    fi
     # new forced backup starts
     # === Check current Git branch ===
     CURRENT_BRANCH=$(sudo -u pi git rev-parse --abbrev-ref HEAD)

--- a/install-picochess.sh
+++ b/install-picochess.sh
@@ -244,6 +244,7 @@ cp etc/gamesdb.service /etc/systemd/system/
 cp etc/picochess-update.service /etc/systemd/system/
 cp etc/run-picochess-if-flagged.sh /usr/local/bin/
 chmod +x /usr/local/bin/run-picochess-if-flagged.sh
+chmod +x /opt/picochess/check-update-status.sh
 touch /var/log/picochess-update.log /var/log/picochess-last-update
 chown root:root /var/log/picochess-*
 systemctl daemon-reload

--- a/picochess.py
+++ b/picochess.py
@@ -856,6 +856,7 @@ async def main() -> None:
             self.shared = shared
             self.non_main_tasks = non_main_tasks
             self.update_status = None
+            self.git_status = None
             ###########################################
 
             # try the given engine first and if that fails the first from "engines.ini" then exit
@@ -890,13 +891,17 @@ async def main() -> None:
         async def initialise(self, time_text):
             """Due to use of async some initialisation is moved here"""
 
-            self.update_status = self.get_last_update_status()  # issue #88
+            # issue 106 - get update and git status information for the user
+            self.update_status = self.get_last_update_status()
             logger.info("Update status: %s", self.update_status)
             # This is shown for a very short time - you can also see it in the menu
             if self.update_status:
                 self.state.dgttranslate.set_last_updated_info(self.update_status)
                 msg = Message.SHOW_TEXT(text_string=self.update_status)
                 await DisplayMsg.show(msg)
+            self.git_status = self.get_git_status()
+            if self.git_status:
+                self.state.dgttranslate.set_git_info(self.git_status)
 
             engine_file_to_load = self.state.engine_file  # assume not mame
             if "/mame/" in self.state.engine_file and self.state.dgtmenu.get_engine_rdisplay():
@@ -1094,9 +1099,33 @@ async def main() -> None:
                 # Return stripped output
                 return result.stdout.strip()
 
-            except Exception as e:
+            except Exception:
                 # Optionally log or print error
                 logger.info("Error running update status script")
+                return None
+
+        def get_git_status(self) -> str | None:
+            """
+            Runs the check-git-status.sh script and returns the git status string.
+            Returns None if there was an error running the script.
+            """
+            script_path = "/opt/picochess/check-git-status.sh"
+
+            try:
+                result = subprocess.run(
+                    [script_path],
+                    cwd="/opt/picochess",
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,  # capture output as string
+                    check=False,  # don't raise exception on non-zero exit
+                )
+
+                # Return the full output string from the shell script
+                return result.stdout.strip()
+
+            except Exception:
+                logger.info("Error running git status script:")
                 return None
 
         async def think(


### PR DESCRIPTION
This is a PR for
#106 

But it also touches
#59 - fix German text to be English for the update menu, not Aktualiseren :-)
#88 - protect users against engines folder being updated when you update (lines added in install script)

Now there is a user menu to get latest update status ... and to see the git info on if we are in master or in a development branch or perhaps in a tag or commit. These are both based on 2 new shell scripts that the user can of course run at any time to check himself. They were designed to keep the text short.
The new script files are:
- check-update-status.sh
- check-git-status.sh

Typical update status return values:
upd: 5d ago
upd: failed
upd: never

Typical git status return values:
git:none
git:master
git:v1.2.3
git:1a2b3c

When pico starts it shortly display the update info on the clock... but it goes over so fast and I am not sure how I can slow it down. If you have fast eyes you can see if it states "failed"... If we would have a sound file to play "latest update failed" we could play that when the text contains "failed"


This needs to be tested before we merge it.

