### PR TITLE
Hotfix. Avoid crashing when add_time is invoked mid-move - when user forces a move or alternative move

### DIFF
--- a/timecontrol.py
+++ b/timecontrol.py
@@ -202,7 +202,11 @@ class TimeControl(object):
 
     def add_time(self, color):
         """Add the increment value to the color given."""
-        assert self.internal_running() is False, "internal clock still running for: %s" % self.run_color
+        if self.internal_running():
+            logger.debug(
+                "add_time requested while internal clock running; stopping active color %s", self.run_color
+            )
+            self.stop_internal(log=False)
         if self.mode == TimeMode.FISCHER:
             # log times - issue #184
             w_hms, b_hms = self._log_time()
@@ -220,7 +224,11 @@ class TimeControl(object):
 
     def sub_online_time(self, color, i_dec):
         """Add the increment value to the color given."""
-        assert self.internal_running() is False, "internal clock still running for: %s" % self.run_color
+        if self.internal_running():
+            logger.debug(
+                "sub_online_time requested while internal clock running; stopping active color %s", self.run_color
+            )
+            self.stop_internal(log=False)
 
         # log times - issue #184
         w_hms, b_hms = self._log_time()
@@ -235,7 +243,11 @@ class TimeControl(object):
 
     def add_game2(self, color):
         """Add the tournamment game 2 value to the color given."""
-        assert self.internal_running() is False, "internal clock still running for: %s" % self.run_color
+        if self.internal_running():
+            logger.debug(
+                "add_game2 requested while internal clock running; stopping active color %s", self.run_color
+            )
+            self.stop_internal(log=False)
         if self.moves_to_go_orig > 0:
             # log times - issue #184
             w_hms, b_hms = self._log_time()


### PR DESCRIPTION
Replacing the assertion in add_time/sub_online_time/add_game2 with a defensive stop_internal prevents force-move or alternative-move races from aborting the main loop. If the internal clock is still running when we adjust the time, we now log and stop it first—keeping behaviour identical in normal play while eliminating the intermittent assertion failure on line 205.