### PR TITLE
149 switch sides immediately after loading a game

### DIFF
--- a/picochess.py
+++ b/picochess.py
@@ -3071,6 +3071,8 @@ async def main() -> None:
                     self.state.interaction_mode = old_interaction_mode
                 else:
                     self.state.interaction_mode = Mode.NORMAL
+                self.state.dgtmenu.set_mode(self.state.interaction_mode)
+                await self.engine_mode()
             # else remain in non-playing mode - as set above
 
             self.state.flag_picotutor = True  # switch tutor back on


### PR DESCRIPTION
If you load a game and its not yet finished it should go into normal mode so that you can continue playing it.
The master branch crashed if you tried to switch sides immediately after loading a game.

Now with this change any loaded unfinished game is automatically in mode normal and you can switch sides immediatelly.

A bug fix for issue #149 