### PR TITLE
info analysis after engine move not yet played by user on an eboard

### DIFF
--- a/dgt/display.py
+++ b/dgt/display.py
@@ -1295,25 +1295,17 @@ class DgtDisplay(DisplayMsg):
             await DispatchDgt.fire(message.play_mode_text)
 
         elif isinstance(message, Message.NEW_SCORE):
-            if self.play_move == chess.Move.null():
-                # issue #45 - skip if user has not made computer move on eboard
-                await self._process_new_score(message)
+            await self._process_new_score(message)
 
         elif isinstance(message, Message.BOOK_MOVE):
-            if self.play_move == chess.Move.null():
-                # issue #45 - skip if user has not made computer move on eboard
-                self.score = self.dgttranslate.text("N10_score", None)
-                await DispatchDgt.fire(self.dgttranslate.text("N10_bookmove"))
+            self.score = self.dgttranslate.text("N10_score", None)
+            await DispatchDgt.fire(self.dgttranslate.text("N10_bookmove"))
 
         elif isinstance(message, Message.NEW_PV):
-            if self.play_move == chess.Move.null():
-                # issue #45 - skip if user has not made computer move on eboard
-                await self._process_new_pv(message)
+            await self._process_new_pv(message)
 
         elif isinstance(message, Message.NEW_DEPTH):
-            if self.play_move == chess.Move.null():
-                # issue #45 - skip if user has not made computer move on eboard
-                self.depth = message.depth
+            self.depth = message.depth
 
         elif isinstance(message, Message.IP_INFO):
             self.dgtmenu.int_ip = message.info["int_ip"]


### PR DESCRIPTION
This solution would start to show the new analysis info (pv, score, depth) for the board situation after the engine move as soon as the engine move has been received from the engine and announced to the user. 

.... If we wait for the user to make the move on the board we might lose some information due to the fact that updates are now only done when deeper depth has been found.

Without this fix you will get a delay in the info especially in situations where you wait for a while to carry out the engine move on the eboard.


