### PR TITLE
Tweaks for 1280x720 display

### DIFF
--- a/web/picoweb/static/css/responsive/1280x800.css
+++ b/web/picoweb/static/css/responsive/1280x800.css
@@ -168,17 +168,21 @@
         padding-top: 5px !important;
     }
     #BookTable_wrapper {
-        min-height: 235px !important;
-        max-height: 320px;
+        min-height: 200px !important;
+        max-height: 215px;
         overflow-y: auto;
         overflow-x: hidden
     }
     #GameTable_wrapper {
         min-height: 200px;
-        max-height: 320px;
+        max-height: 215px;
         overflow-y: auto;
     }
 	
+    .scan-controls {
+        padding: 8px !important;
+    }
+
     .scroll_engine {
         height: 100%;
         max-height: 100%;


### PR DESCRIPTION
The Book tab has a double scrollbar on the 7" 1280x720 Touch Display 2, because the area is slightly too big. The Scan tab has a scroll bar for the same reason. These tweaks will remove the extra bars.