### PR TITLE
pgn_engine: refactor transfer file to read original PGN file instead

### DIFF
--- a/picochess.py
+++ b/picochess.py
@@ -2953,24 +2953,26 @@ async def main() -> None:
                             pgn_fen = headers.get("FEN", "")
                             pgn_result = headers.get("Result", "")
 
-                            update_speed = 1.0
-                            if pgn_white:
-                                await DisplayMsg.show(Message.SHOW_TEXT(text_string=pgn_white))
-                                await asyncio.sleep(update_speed)
-                            if pgn_black:
-                                await DisplayMsg.show(Message.SHOW_TEXT(text_string=pgn_black))
-                                await asyncio.sleep(update_speed)
-
-                            if pgn_result:
-                                await DisplayMsg.show(Message.SHOW_TEXT(text_string=pgn_result))
+                            async def show_pgn_headers():
+                                update_speed = 1.0
+                                if pgn_white:
+                                    await DisplayMsg.show(Message.SHOW_TEXT(text_string=pgn_white))
+                                    await asyncio.sleep(update_speed)
+                                if pgn_black:
+                                    await DisplayMsg.show(Message.SHOW_TEXT(text_string=pgn_black))
+                                    await asyncio.sleep(update_speed)
+                                if pgn_result:
+                                    await DisplayMsg.show(Message.SHOW_TEXT(text_string=pgn_result))
+                                    await asyncio.sleep(update_speed)
+                                if "mate in" in pgn_problem or "Mate in" in pgn_problem:
+                                    await DisplayMsg.show(Message.SHOW_TEXT(text_string=pgn_problem))
+                                else:
+                                    await DisplayMsg.show(Message.SHOW_TEXT(text_string=pgn_game_name))
                                 await asyncio.sleep(update_speed)
 
                             if "mate in" in pgn_problem or "Mate in" in pgn_problem:
                                 await self.set_fen_from_pgn(pgn_fen)
-                                await DisplayMsg.show(Message.SHOW_TEXT(text_string=pgn_problem))
-                            else:
-                                await DisplayMsg.show(Message.SHOW_TEXT(text_string=pgn_game_name))
-                            await asyncio.sleep(update_speed)
+                            asyncio.create_task(show_pgn_headers())
 
                     else:
                         if self.state.done_computer_fen and not self.state.position_mode:


### PR DESCRIPTION
Don't read pgn_engine transfer file any more. Read only the source PGN file instead.

Store all the data that needs to be stored for later use:
- in _self.shared["headers"]_ and in two new state variables:
- _self.state.pgn_engine_total_halfmoves_, half‑move count of the PGN game (for end detection in guess mode).
- _self.state.pgn_engine_result_, final Result tag from the PGN.

Note: I have not yet taken out the transfer file writing from the pgn_engine.py itself. These changes are only on the main code to make picochess independent of the transfer file.