### PR TITLE
Add support for the Chessnut Move e-board

### DIFF
--- a/eboard/chessnut/board.py
+++ b/eboard/chessnut/board.py
@@ -14,6 +14,7 @@
 import asyncio
 import logging
 import queue
+from typing import Dict, Optional
 
 from eboard.eboard import EBoard
 from utilities import DisplayMsg
@@ -30,7 +31,7 @@ logger = logging.getLogger(__name__)
 class ChessnutBoard(EBoard):
     def __init__(self, loop: asyncio.AbstractEventLoop):
         self.agent = None
-        self.appque = queue.Queue()
+        self.appque: queue.Queue[Dict[str, Optional[str]]] = queue.Queue()
         self.connected = False
         self.loop = loop
 
@@ -41,6 +42,7 @@ class ChessnutBoard(EBoard):
         dpos[int(uci_move[3]) - 1][ord(uci_move[2]) - ord("a")] = 1  # to
         if self.agent is not None:
             self.agent.set_led(dpos)
+            self.agent.auto_move(uci_move)
 
     def light_square_on_revelation(self, square: str):
         logger.debug("turn on LEDs - square: %s", square)
@@ -90,7 +92,7 @@ class ChessnutBoard(EBoard):
                 except queue.Empty:
                     pass
                 current_time = self.loop.time()
-                if current_time - last_battery_request > 30:  # request battery state every 30 seconds
+                if current_time - last_battery_request > 3:  # request battery status every 3 seconds
                     last_battery_request = current_time
                     self.agent.request_battery_status()
 

--- a/eboard/chessnut/chessnut_agent.py
+++ b/eboard/chessnut/chessnut_agent.py
@@ -61,6 +61,9 @@ class ChessnutAgent:
     def set_led(self, pos):
         self.brd.set_led(pos)
 
+    def auto_move(self, uci_move: str):
+        self.brd.auto_move(uci_move)
+
     def request_battery_status(self):
         self.brd.request_battery_status()
 

--- a/eboard/chessnut/command.py
+++ b/eboard/chessnut/command.py
@@ -11,11 +11,18 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+import chess
 
-def set_led(pos, is_reversed: bool):
+FEN_TO_CHESSNUT = {
+    "p": 4, "r": 8, "n": 5, "b": 3, "q": 1, "k": 2,
+    "P": 7, "R": 6, "N": 10, "B": 9, "Q": 11, "K": 12,
+}
+
+
+def set_led_regular_chessnut(pos, is_reversed: bool) -> bytes:
     """
-    Set LEDs according to `position`.
-    :param pos: `position` array, field != 0 indicates a led that should be on
+    Set LEDs according to `position` on a regular Chessnut e-board.
+    :param pos: `position` array, field != 0 indicates an LED that should be on
     :param is_reversed: whether the colors on the board are reversed
     """
     leds = bytearray(8)
@@ -42,13 +49,108 @@ def _set_bit(data: bytearray, pos: int, val: int):
     data[posByte] = newByte
 
 
-def set_led_off():
+def set_led_off_regular_chessnut():
     return b"\x0a\x08\x00\x00\x00\x00\x00\x00\x00\x00"
 
 
-def request_realtime_mode():
+def set_led_chessnut_move(pos, is_reversed: bool) -> bytes:
+    """
+    Set LEDs according to `position` on a Chessnut Move e-board.
+    :param pos: `position` array, field != 0 indicates an LED that should be on
+    :param is_reversed: whether the colors on the board are reversed
+    """
+    leds = bytearray(32)
+    for y in range(8):
+        for x in range(8):
+            if pos[y][x] != 0:
+                internal = y * 8 + x
+                fen_index = internal if is_reversed else (63 - internal)
+                _set_led_color(leds, fen_index, 3)  # 3 = blue LED
+
+    prefix = bytearray(2)
+    prefix[0] = 0x43
+    prefix[1] = 0x20
+    return prefix + leds
+
+
+def set_led_off_chessnut_move() -> bytes:
+    cmd = bytearray(34)
+    cmd[0] = 0x43
+    cmd[1] = 0x20
+    return cmd
+
+
+def _set_led_color(data: bytearray, fen_index: int, color_nibble: int):
+    """
+    Packs a 4‑bit color value into the correct nibble.
+    """
+    byte_index = fen_index // 2
+    lower = (fen_index % 2 == 0)
+    existing = data[byte_index]
+    if lower:
+        existing = (existing & 0xF0) | (color_nibble & 0x0F)
+    else:
+        existing = (existing & 0x0F) | ((color_nibble & 0x0F) << 4)
+    data[byte_index] = existing
+
+
+def request_realtime_mode() -> bytes:
     return b"\x21\x01\x00"
 
 
-def request_battery_status():
+def request_battery_status() -> bytes:
     return b"\x29\x01\x00"
+
+
+def request_battery_status_chessnut_move() -> bytes:
+    return b"\x41\x01\x0c"
+
+
+def _fen_to_board64(fen: str):
+    """Convert piece-placement FEN to 64 nibbles in a1=0 order."""
+    board = [0] * 64
+    rows = fen.split("/")
+    for fen_row_idx, row in enumerate(rows):
+        rank = 8 - fen_row_idx
+        base = (rank - 1) * 8
+        file = 0
+        for ch in row:
+            if ch.isdigit():
+                file += int(ch)
+            else:
+                board[base + file] = FEN_TO_CHESSNUT[ch]
+                file += 1
+    return board
+
+
+def _encode_board(board64) -> bytes:
+    out = bytearray(32)
+    idx = 0
+    for row in range(7, -1, -1):
+        for col in range(3, -1, -1):
+            hi = board64[idx]
+            lo = board64[idx + 1]
+            out[row * 4 + col] = (hi << 4) | lo
+            idx += 2
+    return out
+
+
+def send_auto_move_fen(fen: str, uci_move: str) -> bytes:
+    board = chess.Board(fen + " w KQkq - 0 1")
+    move = chess.Move.from_uci(uci_move)
+    if not board.is_legal(move):
+        board = chess.Board(fen + " b KQkq - 0 1")
+        if not board.is_legal(move):
+            return bytearray(0)
+    board.push(move)
+
+    new_fen = board.board_fen()
+    board64 = _fen_to_board64(new_fen)
+    encoded = _encode_board(board64)
+
+    cmd = bytearray(35)
+    cmd[0] = 0x42
+    cmd[1] = 0x21
+    cmd[2:34] = encoded
+    cmd[34] = 0  # force = true
+    return cmd

--- a/tests/test_chessnut_command.py
+++ b/tests/test_chessnut_command.py
@@ -21,24 +21,60 @@ import eboard.chessnut.command as cmd
 
 class TestCommand(unittest.TestCase):
 
-    def test_set_led(self):
+    def test_set_led_off_regular_chessnut(self):
+        arr = cmd.set_led_off_regular_chessnut()
+        self.assertEqual(b"0a080000000000000000", binascii.hexlify(arr))
+
+    def test_set_led_regular_chessnut(self):
         position = [[0 for _ in range(8)] for _ in range(8)]
         position[2][2] = 1
-        arr = cmd.set_led(position, False)
-        self.assertEqual(binascii.hexlify(arr), b"0a080000000000200000")
+        arr = cmd.set_led_regular_chessnut(position, False)
+        self.assertEqual(b"0a080000000000200000", binascii.hexlify(arr))
 
-    def test_set_leds_e2_e4(self):
+    def test_set_leds_e2_e4_regular_chessnut(self):
         position = [[0 for _ in range(8)] for _ in range(8)]
         position[1][4] = 1  # e2
         position[3][4] = 1  # e4
-        arr = cmd.set_led(position, False)
-        self.assertEqual(binascii.hexlify(arr), b"0a080000000008000800")
+        arr = cmd.set_led_regular_chessnut(position, False)
+        self.assertEqual(b"0a080000000008000800", binascii.hexlify(arr))
 
-    def test_set_led_initial_position_reversed(self):
+    def test_set_led_initial_position_reversed_regular_chessnut(self):
         position = [[0 for _ in range(8)] for _ in range(8)]
         position[2][2] = 1
-        arr = cmd.set_led(position, True)
-        self.assertEqual(binascii.hexlify(arr), b"0a080000040000000000")
+        arr = cmd.set_led_regular_chessnut(position, True)
+        self.assertEqual(b"0a080000040000000000", binascii.hexlify(arr))
+
+    def test_set_led_off_chessnut_move(self):
+        arr = cmd.set_led_off_chessnut_move()
+        self.assertEqual(b"43200000000000000000000000000000000000000000000000000000000000000000",
+                         binascii.hexlify(arr))
+
+    def test_set_led_chessnut_move(self):
+        position = [[0 for _ in range(8)] for _ in range(8)]
+        position[2][2] = 1
+        arr = cmd.set_led_chessnut_move(position, False)
+        self.assertEqual(b"43200000000000000000000000000000000000000000000030000000000000000000",
+                         binascii.hexlify(arr))
+
+    def test_set_leds_e2_e4_chessnut_move(self):
+        position = [[0 for _ in range(8)] for _ in range(8)]
+        position[1][4] = 1  # e2
+        position[3][4] = 1  # e4
+        arr = cmd.set_led_chessnut_move(position, False)
+        self.assertEqual(b"43200000000000000000000000000000000000300000000000000030000000000000",
+                         binascii.hexlify(arr))
+
+    def test_set_led_initial_position_reversed_chessnut_move(self):
+        position = [[0 for _ in range(8)] for _ in range(8)]
+        position[2][2] = 1
+        arr = cmd.set_led_chessnut_move(position, True)
+        self.assertEqual(b"43200000000000000000000300000000000000000000000000000000000000000000",
+                         binascii.hexlify(arr))
+
+    def test_send_auto_move_fen(self):
+        arr = cmd.send_auto_move_fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR", "e2e4")
+        self.assertEqual(b"422158233185444444440000000000000000007000000000000077077777a6c99b6a00",
+                         binascii.hexlify(arr))
 
 
 if __name__ == "__main__":

--- a/tests/test_chessnut_parser.py
+++ b/tests/test_chessnut_parser.py
@@ -76,23 +76,43 @@ class TestParser(unittest.TestCase):
         parser.parse(bytearray.fromhex("A6C99B6AFFFFFFFF"))
         MockedParserCallback.board_update.assert_called_once_with("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR")
 
-    def test_battery_charging(self, MockedParserCallback):
+    def test_battery_charging_regular_chessnut(self, MockedParserCallback):
         data = bytearray.fromhex("2a026401")
         Parser(MockedParserCallback).parse(data)
         MockedParserCallback.battery.assert_called_once_with(100, Battery.CHARGING)
 
-    def test_battery_discharging(self, MockedParserCallback):
+    def test_battery_discharging_regular_chessnut(self, MockedParserCallback):
         data = bytearray.fromhex("2a025800")
         Parser(MockedParserCallback).parse(data)
         MockedParserCallback.battery.assert_called_once_with(88, Battery.DISCHARGING)
 
-    def test_battery_low(self, MockedParserCallback):
+    def test_battery_low_regular_chessnut(self, MockedParserCallback):
         data = bytearray.fromhex("2a020900")
         Parser(MockedParserCallback).parse(data)
         MockedParserCallback.battery.assert_called_once_with(9, Battery.LOW)
 
-    def test_battery_exhausted(self, MockedParserCallback):
+    def test_battery_exhausted_regular_chessnut(self, MockedParserCallback):
         data = bytearray.fromhex("2a020400")
+        Parser(MockedParserCallback).parse(data)
+        MockedParserCallback.battery.assert_called_once_with(4, Battery.EXHAUSTED)
+
+    def test_battery_charging_chessnut_move(self, MockedParserCallback):
+        data = bytearray.fromhex("41030c0164")
+        Parser(MockedParserCallback).parse(data)
+        MockedParserCallback.battery.assert_called_once_with(100, Battery.CHARGING)
+
+    def test_battery_discharging_chessnut_move(self, MockedParserCallback):
+        data = bytearray.fromhex("41030c0058")
+        Parser(MockedParserCallback).parse(data)
+        MockedParserCallback.battery.assert_called_once_with(88, Battery.DISCHARGING)
+
+    def test_battery_low_chessnut_move(self, MockedParserCallback):
+        data = bytearray.fromhex("41030c0009")
+        Parser(MockedParserCallback).parse(data)
+        MockedParserCallback.battery.assert_called_once_with(9, Battery.LOW)
+
+    def test_battery_exhausted_chessnut_move(self, MockedParserCallback):
+        data = bytearray.fromhex("41030c0004")
         Parser(MockedParserCallback).parse(data)
         MockedParserCallback.battery.assert_called_once_with(4, Battery.EXHAUSTED)
 


### PR DESCRIPTION
This pull request adds support for the Chessnut Move e-board.
The Chessnut Move has some differences in the protocol compared to regular Chessnut e-boards:

- The battery and LED commands are different.
- There is a new command to send a FEN to the e-board to move the pieces to the specified FEN.

The code automatically detects the Chessnut board type by looking at the battery result.
When a LED command with a move is received, the FEN command is sent to the Chessnut Move board so it automatically makes the move.
Not included in this pull request is a way to automatically set up the pieces to the initial position.

Another important change is that the Chessnut Move takes longer to start up and be ready (indicated with two green lights). A bluetooth connection is theoretically possible before the board is ready.
To prevent this, start the e-board before starting up PicoChess.