### PR TITLE
dont send options to engine without lock

### DIFF
--- a/uci/engine.py
+++ b/uci/engine.py
@@ -964,7 +964,8 @@ class UciEngine(object):
         try:
             # issue 85 - remove options not allowed by engine before sending
             options = self.filter_options(self.options, self.engine.options)
-            await self.engine.configure(options)
+            async with self.engine_lock:
+                await self.engine.configure(options)
         except chess.engine.EngineError as e:
             logger.warning(e)
 


### PR DESCRIPTION
this exception was found by gkalab when aborting or starting a  new game

the problem was that the new send options was coming "too quickly" after the previous "stop". This small change should protect against that happening.