### PR TITLE
Add picochess.ini settings for web speech sound

### DIFF
--- a/configuration.py
+++ b/configuration.py
@@ -4,6 +4,19 @@ import os
 from utilities import version
 
 
+def str_to_bool(value: str) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    normalized = value.strip().lower()
+    if normalized in ("1", "true", "yes", "on"):
+        return True
+    if normalized in ("0", "false", "no", "off"):
+        return False
+    raise configargparse.ArgumentTypeError("Boolean value expected.")
+
+
 class Configuration:
     def __init__(self):
         # Command line argument parsing
@@ -117,6 +130,18 @@ class Configuration:
             type=int,
             metavar="PORT",
             help="launch web server",
+        )
+        self.parser.add_argument(
+            "--web-speech-local",
+            type=str_to_bool,
+            default=False,
+            help="enable speech in web client when accessed via localhost",
+        )
+        self.parser.add_argument(
+            "--web-speech-remote",
+            type=str_to_bool,
+            default=True,
+            help="enable speech in web client when accessed remotely",
         )
         self.parser.add_argument("-m", "--email", type=str, help="email used to send pgn/log files", default=None)
         self.parser.add_argument("-ms", "--smtp-server", type=str, help="address of email server", default=None)

--- a/picochess.ini.example-dgtpi-clock
+++ b/picochess.ini.example-dgtpi-clock
@@ -210,6 +210,10 @@ pgn-elo = 1500
 ## The port of the built-in web server
 #web-server = 8080
 web-server = 80
+## Enable speech synthesis in the web client when accessed from localhost
+web-speech-local = False
+## Enable speech synthesis in the web client when accessed remotely
+web-speech-remote = True
 
 ## When in ponder mode decides how long each info is displayed. Default is 3 secs.
 ## Must be between 1 to 8 secs.

--- a/picochess.ini.example-web-aarch64
+++ b/picochess.ini.example-web-aarch64
@@ -210,6 +210,10 @@ pgn-elo = 1500
 ## The port of the built-in web server
 #web-server = 8080
 web-server = 80
+## Enable speech synthesis in the web client when accessed from localhost
+web-speech-local = False
+## Enable speech synthesis in the web client when accessed remotely
+web-speech-remote = True
 
 ## When in ponder mode decides how long each info is displayed. Default is 3 secs.
 ## Must be between 1 to 8 secs.

--- a/picochess.ini.example-web-x86_64
+++ b/picochess.ini.example-web-x86_64
@@ -210,6 +210,10 @@ pgn-elo = 1500
 ## The port of the built-in web server
 #web-server = 8080
 web-server = 80
+## Enable speech synthesis in the web client when accessed from localhost
+web-speech-local = False
+## Enable speech synthesis in the web client when accessed remotely
+web-speech-remote = True
 
 ## When in ponder mode decides how long each info is displayed. Default is 3 secs.
 ## Must be between 1 to 8 secs.

--- a/picochess.py
+++ b/picochess.py
@@ -785,6 +785,8 @@ async def main() -> None:
     if args.web_server_port:
         my_web_server = WebServer()
         shared: dict = {}
+        shared["web_speech_local"] = args.web_speech_local
+        shared["web_speech_remote"] = args.web_speech_remote
         # moved starting WebDisplayt and WebVr here so that they are in same main loop
         logger.info("initializing message queues")
         my_web_display = WebDisplay(shared, main_loop)

--- a/web/picoweb/static/js/app.js
+++ b/web/picoweb/static/js/app.js
@@ -41,6 +41,9 @@ var simpleNags = {
 };
 // Speech toggle for the web client (set via setSpeechMuted)
 var speechMuted = false;
+if (typeof window !== "undefined" && window.picoWebConfig && window.picoWebConfig.webSpeech === false) {
+    speechMuted = true;
+}
 
 var speechAvailable = true
 if (typeof speechSynthesis === "undefined") {

--- a/web/picoweb/templates/clock.html
+++ b/web/picoweb/templates/clock.html
@@ -537,6 +537,10 @@
                 </div>
             </div>
         </div>
+        <script>
+            window.picoWebConfig = window.picoWebConfig || {};
+            window.picoWebConfig.webSpeech = {{ "true" if web_speech else "false" }};
+        </script>
         <script type="text/javascript" src="/static/js/app.js?v=2"></script>
         <script>
             document.addEventListener('DOMContentLoaded', function () {


### PR DESCRIPTION
This adds two new web speech settings in picochess.ini so users can control speech separately for localhost and remote web clients. The server now passes the computed setting into the web template, and the web client uses it to set the initial speech muted state. Default behavior (when unset) is muted on localhost and enabled on remote.

Changes:
Add web-speech-local and web-speech-remote config options.
Pass selected value to clock.html and apply it in app.js.

Example of default configuration:
Enable speech synthesis in the web client when accessed from localhost
web-speech-local = False
Enable speech synthesis in the web client when accessed remotely
web-speech-remote = True
