### PR TITLE
Fix PGN move list scrollbar

### DIFF
--- a/web/picoweb/static/css/base.css
+++ b/web/picoweb/static/css/base.css
@@ -177,6 +177,17 @@ div.dataTables_wrapper div.dataTables_length select {
     height: 30vh;
     overflow: auto;
     margin-bottom: 1vh;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+}
+
+.scroll_movelist .card-body {
+    flex: 1 1 auto;
+    min-height: 0;
+    height: 100%;
+    max-height: 100%;
+    overflow-y: auto;
 }
 
 .scroll_obooklist {

--- a/web/picoweb/static/css/responsive/desktop.css
+++ b/web/picoweb/static/css/responsive/desktop.css
@@ -65,3 +65,13 @@
         color: #adb5bd;
     }
 }
+
+@media (min-width: 1000px) and (max-width: 1100px) and (min-height: 651px) and (max-height: 800px) {
+    .scroll_movelist {
+        height: 25vh;
+        min-height: 160px;
+        max-height: 25vh;
+        overflow-y: auto;
+        overflow-x: hidden;
+    }
+}


### PR DESCRIPTION
The problem this attempts to solve is that for a long game the PGN move window does not show a scroll bar so you cannot see the last moves of your game...

Fix:
- Ensure the PGN move list scrolls inside its card instead of expanding the layout.
- Apply a flex container and inner overflow to keep long games accessible across layouts.

Not sure how many resolutions we need to test this on?