### PR TITLE
document coach-analyser setting in the 3 picochess.ini.example files

### DIFF
--- a/picochess.ini.example-dgtpi-clock
+++ b/picochess.ini.example-dgtpi-clock
@@ -363,6 +363,11 @@ tutor-engine = /opt/picochess/engines/aarch64/a-stockf
 ## Optional: use a tutor engine on a remote machine; falls back to tutor-engine if not found
 #tutor-remote-engine = remote_stockfish
 
+## The coach-analyser setting will make tutor analyse also engine moves, and not as usual only user moves.
+## It will therefore use more CPU as the tutor will be running when the chosen engine is thinking about a move.
+## Default is False. Might be interesting to check mame engine blunders by setting this to True.
+# coach-analyser = True
+
 
 ## Type of e-Board. Supported values: 'certabo', 'chesslink', 'chessnut', 'dgt' (default), 'ichessone', 'noeboard' (play against
 ## engine using web server interface).

--- a/picochess.ini.example-web-aarch64
+++ b/picochess.ini.example-web-aarch64
@@ -363,6 +363,11 @@ tutor-engine = /opt/picochess/engines/aarch64/a-stockf
 ## Optional: use a tutor engine on a remote machine; falls back to tutor-engine if not found
 #tutor-remote-engine = remote_stockfish
 
+## The coach-analyser setting will make tutor analyse also engine moves, and not as usual only user moves.
+## It will therefore use more CPU as the tutor will be running when the chosen engine is thinking about a move.
+## Default is False. Might be interesting to check mame engine blunders by setting this to True.
+# coach-analyser = True
+
 
 ## Type of e-Board. Supported values: 'certabo', 'chesslink', 'chessnut', 'dgt' (default), 'ichessone', 'noeboard' (play against
 ## engine using web server interface).

--- a/picochess.ini.example-web-x86_64
+++ b/picochess.ini.example-web-x86_64
@@ -363,6 +363,11 @@ tutor-engine = /opt/picochess/engines/x86_64/a-stockf
 ## Optional: use a tutor engine on a remote machine; falls back to tutor-engine if not found
 #tutor-remote-engine = remote_stockfish
 
+## The coach-analyser setting will make tutor analyse also engine moves, and not as usual only user moves.
+## It will therefore use more CPU as the tutor will be running when the chosen engine is thinking about a move.
+## Default is False. Might be interesting to check mame engine blunders by setting this to True.
+# coach-analyser = True
+
 
 ## Type of e-Board. Supported values: 'certabo', 'chesslink', 'chessnut', 'dgt' (default), 'ichessone', 'noeboard' (play against
 ## engine using web server interface).


### PR DESCRIPTION
This is a very experimental branch, and I am not sure if we want picotutor to analyse any other engine than mame engines or the PGN Replay engine. But now for starters if you set this in you picochess.ini file:
coach-analyser = True
--> Picotutor will analyse all engine moves (if picotutor is on)

It will then consume more CPU as it will run the picotutor also while the engine is thinking about its move. And when the engine makes its move, it will also use that analysed data to evaluate the engine move with "!!", "??" etc.

I will test this on mame engines and on the PGN Replay engine... And I am thinking that this function should not be active for any modern chess engine, but it could be fun perhaps to get an instant evaluation of blunders made by mame engines....

Highly experimental... We might not want this feature at all... Or we might only want it on the PGN Replay engine, or mames...?