### PR TITLE
Fix desktop layout resizing for chessboard

### DIFF
--- a/web/picoweb/static/css/responsive/desktop.css
+++ b/web/picoweb/static/css/responsive/desktop.css
@@ -3,6 +3,7 @@
     .container-fluid>.row {
         display: flex;
         align-items: stretch;
+        flex-wrap: nowrap;
     }
 
     .scroll-portrait > .container-fluid > .row {
@@ -13,6 +14,7 @@
     .container-fluid>.row>.col {
         display: flex;
         flex-direction: column;
+        min-width: 0;
     }
 
     .container-fluid>.row>.col:last-child>.container {


### PR DESCRIPTION
Prevent the right column from wrapping under the board during window resize.
Keeps the chessboard from expanding to full width on downsize.
No impact to portrait layout (desktop-only media query).

Typical testing that I have done..
Resize across common desktop sizes (e.g., 2000x1400 → 1500x1400 → 1193x850).
In master that 1193x seemed to be the breaking point when you came from a higher resolution. The right hand side columns "fell down" under the chess board, and therefore screen showed an oversize chessboard and had to press F5 to fix the screen.