### PR TITLE
No prompts during installation

### DIFF
--- a/install-picochess.sh
+++ b/install-picochess.sh
@@ -80,7 +80,7 @@ done
 
 if [ "$SKIP_UPDATE" = false ]; then
     echo "starting by upgrading system before installing picochess"
-    apt update && apt upgrade -y
+    DEBIAN_FRONTEND=noninteractive apt update && DEBIAN_FRONTEND=noninteractive apt upgrade -y
 else
     echo "Skipping system update because 'pico' parameter was given."
     echo "Updating Picochess but not system"


### PR DESCRIPTION
Do not prompt the user while the installation script runs, but always accept the default answer.