### PR TITLE
Don't cache web page

### DIFF
--- a/server.py
+++ b/server.py
@@ -617,6 +617,7 @@ class ChessBoardHandler(ServerRequestHandler):
         self.shared = shared
 
     def get(self):
+        self.set_header("Cache-Control", "no-store")
         web_speech = True
         web_audio_backend = False
         tutor_watch_active = False


### PR DESCRIPTION
Tell Chromium not to cache the Picoweb web page. Should solve issue #364 ("auto" gives wrong daylight mode upon boot).