### PR TITLE
BRAIN/HAND hint improvements

### DIFF
--- a/configuration.py
+++ b/configuration.py
@@ -363,36 +363,20 @@ class Configuration:
             help="show game comments based on specific engines (=single) or in general (=all). Default value is off",
         )
         self.parser.add_argument(
-            "-tbhd",
-            "--tutor-brain-hint-duration",
+            "-tbh",
+            "--tutor-brain-hint-display",
             type=int,
-            default=3,
-            choices=range(1, 9),
-            help="BRAIN coach mode: how long the piece-type hint stays on the DGT display before the clock reappears (1-8 secs, default=3)",
-        )
-        self.parser.add_argument(
-            "-tbhp",
-            "--tutor-brain-hint-pause",
-            type=int,
-            default=2,
+            default=0,
             choices=range(0, 9),
-            help="BRAIN coach mode: seconds the clock is paused after the piece-type hint (0=no pause, default=2)",
+            help="BRAIN coach mode: how long the piece-type hint stays on the DGT display (0=until user plays, 1-8 secs). Clock is never paused. Default=0.",
         )
         self.parser.add_argument(
-            "-tbhs",
-            "--tutor-brain-hint-speed",
+            "-tbrt",
+            "--tutor-brain-reveal-text",
             type=str,
-            default=None,
-            choices=["short", "medium", "long", "manual"],
-            help=(
-                "BRAIN/HAND coach mode: preset for hint display speed."
-                " short=faster games (DGT clock hold 2 s, clock pause 1 s);"
-                " medium=standard games (DGT clock hold 4 s, clock pause 3 s);"
-                " long=leisurely/study play (DGT clock hold 6 s, clock pause 6 s);"
-                " manual=use tutor-brain-hint-duration and tutor-brain-hint-pause directly."
-                " Note: hint-duration only affects the DGT clock face; the web display is unaffected."
-                " Overrides tutor-brain-hint-duration and tutor-brain-hint-pause when set to a preset."
-            ),
+            default="on",
+            choices=["on", "off"],
+            help="BRAIN/HAND coach mode: show the tutor's revealed move as text on the DGT clock after the user plays (default=on).",
         )
         self.parser.add_argument(
             "-loc",

--- a/dgt/display.py
+++ b/dgt/display.py
@@ -753,6 +753,8 @@ class DgtDisplay(DisplayMsg):
 
     async def force_leds_off(self, log=False):
         """Clear the rev2 lights if they still on."""
+        self._brain_hint_text = None
+        self._brain_hint_until = 0.0
         if self.leds_are_on:
             if log:
                 logger.warning("(rev) leds still on")
@@ -1304,11 +1306,30 @@ class DgtDisplay(DisplayMsg):
             await self._process_user_move_done(message)
 
         elif isinstance(message, Message.TUTOR_MOVE_REVEAL):
-            # BRAIN/HAND: light the tutor's full move (from+to) on the physical Revelation board.
-            # Cleared automatically when force_leds_off() fires on the next computer move.
-            # The web client handles this separately via the 'TutorMove' WebSocket event in server.py.
+            # Light the tutor's full move on the Revelation board LEDs.
             await DispatchDgt.fire(Dgt.LIGHT_SQUARES(uci_move=message.move.uci(), devs={"ser"}))
             self.leds_are_on = True
+            # Clear any BRAIN piece-hint hold so the reveal text takes over.
+            self._brain_hint_text = None
+            self._brain_hint_until = 0.0
+            # Show the revealed move as text on the DGT clock (if enabled).
+            if self.dgtmenu.get_brain_reveal_text():
+                uci = message.move.uci()          # e.g. "e2e4" or "e7e8q"
+                frm, to = uci[:2], uci[2:4]
+                reveal_text = Dgt.DISPLAY_TEXT(
+                    web_text="Best move: " + frm + "-" + to,
+                    large_text=("Best " + frm + "-" + to).ljust(11)[:11],
+                    medium_text=("Bt " + frm + to).ljust(8)[:8],
+                    small_text=(frm + to).ljust(6)[:6],
+                    beep=False,
+                    maxtime=0,
+                    wait=True,
+                    devs={"ser", "i2c", "web"},
+                )
+                await DispatchDgt.fire(reveal_text)
+                # Hold the reveal text until the engine plays (force_leds_off will clear it).
+                self._brain_hint_text = reveal_text
+                self._brain_hint_until = float("inf")
 
         elif isinstance(message, Message.REVIEW_MOVE_DONE):
             await self._process_review_move_done(message)
@@ -1662,8 +1683,13 @@ class DgtDisplay(DisplayMsg):
                 # within one second.  Any non-BRAIN tutor message (score, best
                 # move, etc.) clears the hold immediately.
                 if message.eval_str.startswith("BRAIN_"):
-                    self._brain_hint_text = hint_text
-                    self._brain_hint_until = self.loop.time() + float(self.dgtmenu.get_brain_hint_duration())
+                    hint_display = self.dgtmenu.get_brain_hint_display()
+                    if hint_display > 0:
+                        self._brain_hint_text = hint_text
+                        self._brain_hint_until = self.loop.time() + float(hint_display)
+                    else:
+                        self._brain_hint_text = hint_text
+                        self._brain_hint_until = float("inf")
                 else:
                     self._brain_hint_until = 0.0
             if message.eval_str == "POSOK" or message.eval_str == "ANALYSIS" and self.play_move == chess.Move.null():

--- a/dgt/menu.py
+++ b/dgt/menu.py
@@ -272,8 +272,8 @@ class DgtMenu(object):
         picoexplorer: bool,
         picocomment: PicoComment,
         picocomment_prob: int,
-        brain_hint_duration: int,
-        brain_hint_pause: int,
+        brain_hint_display: int,
+        brain_reveal_text: bool,
         contlast: bool,
         altmove: bool,
         dgttranslate: DgtTranslate,
@@ -291,8 +291,8 @@ class DgtMenu(object):
         self.menu_picotutor_picocoach = picocoach
         self.menu_picotutor_picoexplorer = picoexplorer
         self.menu_picotutor_picocomment = picocomment
-        self.menu_picotutor_brain_hint_duration = brain_hint_duration
-        self.menu_picotutor_brain_hint_pause = brain_hint_pause
+        self.menu_picotutor_brain_hint_display = brain_hint_display
+        self.menu_picotutor_brain_reveal_text = brain_reveal_text
 
         self.menu_game = Game.NEW
         self.menu_game_end = GameEnd.WHITE_WINS
@@ -769,8 +769,8 @@ class DgtMenu(object):
         self.res_picotutor_picoexplorer = self.menu_picotutor_picoexplorer
         self.res_picotutor_picocomment = self.menu_picotutor_picocomment
         self.res_picotutor_picocomment_prob = int(self.menu_picotutor_picocomment_prob_list)
-        self.res_picotutor_brain_hint_duration = self.menu_picotutor_brain_hint_duration
-        self.res_picotutor_brain_hint_pause = self.menu_picotutor_brain_hint_pause
+        self.res_picotutor_brain_hint_display = self.menu_picotutor_brain_hint_display
+        self.res_picotutor_brain_reveal_text = self.menu_picotutor_brain_reveal_text
         self.res_picotutor = self.menu_picotutor
 
         self.res_game_game_save = self.menu_game_save
@@ -890,13 +890,13 @@ class DgtMenu(object):
         """Get the flag."""
         return self.res_picotutor_picoexplorer
 
-    def get_brain_hint_duration(self):
-        """BRAIN coach mode: seconds the piece-type hint stays on the DGT display."""
-        return self.res_picotutor_brain_hint_duration
+    def get_brain_hint_display(self):
+        """Return brain hint display duration (0=until user plays, 1-8=seconds)."""
+        return self.res_picotutor_brain_hint_display
 
-    def get_brain_hint_pause(self):
-        """BRAIN coach mode: seconds the clock is paused after the piece-type hint (0 = no pause)."""
-        return self.res_picotutor_brain_hint_pause
+    def get_brain_reveal_text(self):
+        """Return True if tutor move reveal should be shown as text on DGT clock."""
+        return self.res_picotutor_brain_reveal_text
 
     def get_game_altmove(self):
         """Get the flag."""

--- a/dgt/translate.py
+++ b/dgt/translate.py
@@ -1023,6 +1023,7 @@ class DgtTranslate(object):
                 frtxt = entxt
                 estxt = entxt
             elif "BRAIN_PAWN" in msg:
+                beep = False
                 entxt = Dgt.DISPLAY_TEXT(
                     web_text="Play a pawn move",
                     large_text="Play Pawn  ",
@@ -1060,6 +1061,7 @@ class DgtTranslate(object):
                     small_text="peon  ",
                 )
             elif "BRAIN_KNIGHT" in msg:
+                beep = False
                 entxt = Dgt.DISPLAY_TEXT(
                     web_text="Play a knight move",
                     large_text="Play Knight",
@@ -1097,6 +1099,7 @@ class DgtTranslate(object):
                     small_text="caball",
                 )
             elif "BRAIN_BISHOP" in msg:
+                beep = False
                 entxt = Dgt.DISPLAY_TEXT(
                     web_text="Play a bishop move",
                     large_text="Play Bishop",
@@ -1134,6 +1137,7 @@ class DgtTranslate(object):
                     small_text="alfil ",
                 )
             elif "BRAIN_ROOK" in msg:
+                beep = False
                 entxt = Dgt.DISPLAY_TEXT(
                     web_text="Play a rook move",
                     large_text="Play Rook  ",
@@ -1171,6 +1175,7 @@ class DgtTranslate(object):
                     small_text="torre ",
                 )
             elif "BRAIN_QUEEN" in msg:
+                beep = False
                 entxt = Dgt.DISPLAY_TEXT(
                     web_text="Play a queen move",
                     large_text="Play Queen ",
@@ -1208,6 +1213,7 @@ class DgtTranslate(object):
                     small_text="dama  ",
                 )
             elif "BRAIN_KING" in msg:
+                beep = False
                 entxt = Dgt.DISPLAY_TEXT(
                     web_text="Play a king move",
                     large_text="Play King  ",

--- a/picochess.ini.example-dgtpi-clock
+++ b/picochess.ini.example-dgtpi-clock
@@ -371,22 +371,15 @@ tutor-watcher = False
 #tutor-coach = lift
 tutor-coach = off
 
-## BRAIN/HAND coach: hint display speed preset.
-##   short  — faster games        (DGT clock hold 2 s, clock pause 1 s)
-##   medium — standard games      (DGT clock hold 4 s, clock pause 3 s)  [default]
-##   long   — leisurely / study   (DGT clock hold 6 s, clock pause 6 s)
-##   manual — use tutor-brain-hint-duration and tutor-brain-hint-pause directly
-## Note: tutor-brain-hint-duration only affects the DGT clock face; the web display is unaffected.
-## The preset takes precedence over the two individual values below.
-## Use 'manual' (or set via the web settings page) to control duration and pause individually.
-#tutor-brain-hint-speed = medium
-tutor-brain-hint-speed = medium
+## BRAIN coach: how long the piece-type hint stays on the DGT clock display.
+##   0 = show until the user plays their move (default)
+##   1-8 = number of seconds the hint is shown; clock is never paused
+#tutor-brain-hint-display = 0
 
-## Individual values — only used when tutor-brain-hint-speed = manual:
-## How many seconds the piece-type hint stays on the DGT clock. Range 1–8, default 3.
-#tutor-brain-hint-duration = 3
-## How many seconds the clock is paused after the hint. 0 = no pause. Range 0–8, default 2.
-#tutor-brain-hint-pause = 2
+## BRAIN/HAND coach: show the tutor's revealed move as text on the DGT clock after the user plays.
+##   on  = display move text on DGT clock (default)
+##   off = LEDs only, no clock text
+#tutor-brain-reveal-text = on
 
 ## Engine used for PicoTutor analysis. Default is /opt/picochess/engines/aarch64/a-stockf.
 tutor-engine = /opt/picochess/engines/aarch64/a-stockf

--- a/picochess.ini.example-web-aarch64
+++ b/picochess.ini.example-web-aarch64
@@ -371,22 +371,15 @@ tutor-watcher = False
 #tutor-coach = lift
 tutor-coach = off
 
-## BRAIN/HAND coach: hint display speed preset.
-##   short  — faster games        (DGT clock hold 2 s, clock pause 1 s)
-##   medium — standard games      (DGT clock hold 4 s, clock pause 3 s)  [default]
-##   long   — leisurely / study   (DGT clock hold 6 s, clock pause 6 s)
-##   manual — use tutor-brain-hint-duration and tutor-brain-hint-pause directly
-## Note: tutor-brain-hint-duration only affects the DGT clock face; the web display is unaffected.
-## The preset takes precedence over the two individual values below.
-## Use 'manual' (or set via the web settings page) to control duration and pause individually.
-#tutor-brain-hint-speed = medium
-tutor-brain-hint-speed = medium
+## BRAIN coach: how long the piece-type hint stays on the DGT clock display.
+##   0 = show until the user plays their move (default)
+##   1-8 = number of seconds the hint is shown; clock is never paused
+#tutor-brain-hint-display = 0
 
-## Individual values — only used when tutor-brain-hint-speed = manual:
-## How many seconds the piece-type hint stays on the DGT clock. Range 1–8, default 3.
-#tutor-brain-hint-duration = 3
-## How many seconds the clock is paused after the hint. 0 = no pause. Range 0–8, default 2.
-#tutor-brain-hint-pause = 2
+## BRAIN/HAND coach: show the tutor's revealed move as text on the DGT clock after the user plays.
+##   on  = display move text on DGT clock (default)
+##   off = LEDs only, no clock text
+#tutor-brain-reveal-text = on
 
 ## Engine used for PicoTutor analysis. Default is /opt/picochess/engines/aarch64/a-stockf.
 tutor-engine = /opt/picochess/engines/aarch64/a-stockf

--- a/picochess.ini.example-web-x86_64
+++ b/picochess.ini.example-web-x86_64
@@ -371,22 +371,15 @@ tutor-watcher = False
 #tutor-coach = lift
 tutor-coach = off
 
-## BRAIN/HAND coach: hint display speed preset.
-##   short  — faster games        (DGT clock hold 2 s, clock pause 1 s)
-##   medium — standard games      (DGT clock hold 4 s, clock pause 3 s)  [default]
-##   long   — leisurely / study   (DGT clock hold 6 s, clock pause 6 s)
-##   manual — use tutor-brain-hint-duration and tutor-brain-hint-pause directly
-## Note: tutor-brain-hint-duration only affects the DGT clock face; the web display is unaffected.
-## The preset takes precedence over the two individual values below.
-## Use 'manual' (or set via the web settings page) to control duration and pause individually.
-#tutor-brain-hint-speed = medium
-tutor-brain-hint-speed = medium
+## BRAIN coach: how long the piece-type hint stays on the DGT clock display.
+##   0 = show until the user plays their move (default)
+##   1-8 = number of seconds the hint is shown; clock is never paused
+#tutor-brain-hint-display = 0
 
-## Individual values — only used when tutor-brain-hint-speed = manual:
-## How many seconds the piece-type hint stays on the DGT clock. Range 1–8, default 3.
-#tutor-brain-hint-duration = 3
-## How many seconds the clock is paused after the hint. 0 = no pause. Range 0–8, default 2.
-#tutor-brain-hint-pause = 2
+## BRAIN/HAND coach: show the tutor's revealed move as text on the DGT clock after the user plays.
+##   on  = display move text on DGT clock (default)
+##   off = LEDs only, no clock text
+#tutor-brain-reveal-text = on
 
 ## Engine used for PicoTutor analysis. Default is /opt/picochess/engines/aarch64/a-stockf.
 tutor-engine = /opt/picochess/engines/x86_64/a-stockf

--- a/picochess.py
+++ b/picochess.py
@@ -1005,8 +1005,8 @@ async def main() -> None:
         args.tutor_explorer,
         PicoComment.from_str(args.tutor_comment),
         args.comment_factor,
-        {"short": 2, "medium": 4, "long": 6}.get(args.tutor_brain_hint_speed, args.tutor_brain_hint_duration),
-        {"short": 1, "medium": 3, "long": 6}.get(args.tutor_brain_hint_speed, args.tutor_brain_hint_pause),
+        args.tutor_brain_hint_display,
+        args.tutor_brain_reveal_text == "on",
         args.continue_game,
         args.alt_move,
         state.dgttranslate,
@@ -1965,15 +1965,10 @@ async def main() -> None:
                 chess.ROOK: "ROOK", chess.QUEEN: "QUEEN", chess.KING: "KING",
             }.get(piece_type, "PAWN")
             logger.info("BRAIN hint: use a %s", piece_name)
-            hint_pause = self.state.dgtmenu.get_brain_hint_pause()
-            if hint_pause > 0:
-                await self.state.stop_clock()
             await DisplayMsg.show(Message.PICOTUTOR_MSG(eval_str="BRAIN_" + piece_name))
-            if hint_pause > 0:
-                await asyncio.sleep(hint_pause)
-                # Only restart the clock if the user hasn't already played during the pause.
-                if _user_turn_and_alive() and self.picotutor_mode():
-                    await self.state.start_clock()
+            hint_display = self.state.dgtmenu.get_brain_hint_display()
+            if hint_display > 0:
+                await asyncio.sleep(hint_display)
 
         def start_brain_hint_timer(self):
             """BRAIN mode: (re)start the 5-second auto-hint timer for the user's turn."""
@@ -3024,11 +3019,8 @@ async def main() -> None:
                 moved_piece_type = self.state.game.piece_type_at(move.from_square)
                 if moved_piece_type != self.state.brain_required_piece_type:
                     logger.info("BRAIN mode: wrong piece type (expected %s, got %s)", self.state.brain_required_piece_type, moved_piece_type)
-                    hint_pause = self.state.dgtmenu.get_brain_hint_pause()
-                    if hint_pause > 0:
-                        await self.state.stop_clock()
                     await DisplayMsg.show(Message.PICOTUTOR_MSG(eval_str="BRAIN_WRONG"))
-                    await asyncio.sleep(max(hint_pause, 1))  # at least 1 s so user sees the message
+                    await asyncio.sleep(1)  # at least 1 s so user sees the message
                     # Re-announce the required piece type: user knows what to play,
                     # green circles reappear on the board.
                     _required = self.state.brain_required_piece_type
@@ -3037,8 +3029,6 @@ async def main() -> None:
                         chess.ROOK: "ROOK", chess.QUEEN: "QUEEN", chess.KING: "KING",
                     }.get(_required, "PAWN")
                     await DisplayMsg.show(Message.PICOTUTOR_MSG(eval_str="BRAIN_" + _piece_name))
-                    if hint_pause > 0:
-                        await self.state.start_clock()  # move was rejected; user must try again
                     return False
 
             # Cancel BRAIN timer and clear enforcement on any valid user move.
@@ -3241,6 +3231,8 @@ async def main() -> None:
                         ):
                             _hand_hint = self.state.brain_best_move
                             self.state.brain_best_move = None  # consume immediately
+                    if _hand_hint is not None:
+                        await DisplayMsg.show(Message.TUTOR_MOVE_REVEAL(move=_hand_hint))
                     game_end = self.state.check_game_state()
                     if game_end:
                         await self.update_elo(game_end.result)
@@ -3302,11 +3294,6 @@ async def main() -> None:
                                 logger.debug("skipping think() after takeback debounce: user turn")
 
                     self.state.last_move = move
-                    # BRAIN/HAND: queue TUTOR_MOVE_REVEAL after USER_MOVE_DONE so the web client
-                    # receives them in order: Fen update → TutorMove green circles (from+to).
-                    # Cleared automatically when the engine announces its move ('Light' event).
-                    if _hand_hint is not None:
-                        await DisplayMsg.show(Message.TUTOR_MOVE_REVEAL(move=_hand_hint))
                 elif self.state.interaction_mode == Mode.REMOTE:
                     msg = Message.USER_MOVE_DONE(
                         move=move, fen=game_before.fen(), turn=game_before.turn, game=self.state.game.copy()

--- a/web/picoweb/templates/settings.html
+++ b/web/picoweb/templates/settings.html
@@ -131,53 +131,30 @@
                 </td>
             </tr>
             <tr>
-                <td><label for="bc-hint-speed">Hint display speed</label></td>
+                <td><label for="bc-hint-display">BRAIN hint display (0=until you play, 1-8 secs)</label></td>
                 <td>
-                    <select id="bc-hint-speed" onchange="bcSpeedChanged()">
-                        <option value="short">short — faster games (DGT clock: 2 s, clock pause: 1 s)</option>
-                        <option value="medium">medium — standard games (DGT clock: 4 s, clock pause: 3 s)</option>
-                        <option value="long">long — leisurely / study play (DGT clock: 6 s, clock pause: 6 s)</option>
-                        <option value="manual">manual — set duration and pause individually</option>
+                    <select id="bc-hint-display">
+                        <option value="0">0 — show until user plays (default)</option>
+                        <option value="1">1 s</option>
+                        <option value="2">2 s</option>
+                        <option value="3">3 s</option>
+                        <option value="4">4 s</option>
+                        <option value="5">5 s</option>
+                        <option value="6">6 s</option>
+                        <option value="7">7 s</option>
+                        <option value="8">8 s</option>
                     </select>
+                    <span style="font-size:0.9em; color:#555; margin-left:6px;">How long the piece-type hint stays on the DGT clock display. Clock is never paused.</span>
                 </td>
             </tr>
-            <tr id="bc-manual-rows" style="display:none;">
-                <td colspan="2">
-                    <table border="0" cellpadding="4" cellspacing="0" style="width:100%; margin-top:2px;">
-                        <tr>
-                            <td style="width:40%; padding-left:1.5em;"><label for="bc-hint-duration">Hint display duration</label></td>
-                            <td>
-                                <select id="bc-hint-duration">
-                                    <option value="1">1 s</option>
-                                    <option value="2">2 s</option>
-                                    <option value="3">3 s (default)</option>
-                                    <option value="4">4 s</option>
-                                    <option value="5">5 s</option>
-                                    <option value="6">6 s</option>
-                                    <option value="7">7 s</option>
-                                    <option value="8">8 s</option>
-                                </select>
-                                <span style="font-size:0.9em; color:#555; margin-left:6px;">How long the piece-type hint stays on the DGT clock display</span>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td style="padding-left:1.5em;"><label for="bc-hint-pause">Clock pause after hint</label></td>
-                            <td>
-                                <select id="bc-hint-pause">
-                                    <option value="0">0 s — no pause</option>
-                                    <option value="1">1 s</option>
-                                    <option value="2">2 s (default)</option>
-                                    <option value="3">3 s</option>
-                                    <option value="4">4 s</option>
-                                    <option value="5">5 s</option>
-                                    <option value="6">6 s</option>
-                                    <option value="7">7 s</option>
-                                    <option value="8">8 s</option>
-                                </select>
-                                <span style="font-size:0.9em; color:#555; margin-left:6px;">Clock is paused while the piece-type hint is displayed</span>
-                            </td>
-                        </tr>
-                    </table>
+            <tr>
+                <td><label for="bc-reveal-text">Show revealed move as text on clock</label></td>
+                <td>
+                    <select id="bc-reveal-text">
+                        <option value="on">on — show tutor move as text after user plays (default)</option>
+                        <option value="off">off — LEDs only, no clock text</option>
+                    </select>
+                    <span style="font-size:0.9em; color:#555; margin-left:6px;">BRAIN/HAND coach: display the tutor's move on the DGT clock when the user plays</span>
                 </td>
             </tr>
         </table>
@@ -255,14 +232,11 @@
             if (normalized === "tutor-comment") {
                 return ["single", "all", "off"];
             }
-            if (normalized === "tutor-brain-hint-speed") {
-                return ["short", "medium", "long", "manual"];
-            }
-            if (normalized === "tutor-brain-hint-pause") {
+            if (normalized === "tutor-brain-hint-display") {
                 return ["0", "1", "2", "3", "4", "5", "6", "7", "8"];
             }
-            if (normalized === "tutor-brain-hint-duration") {
-                return ["1", "2", "3", "4", "5", "6", "7", "8"];
+            if (normalized === "tutor-brain-reveal-text") {
+                return ["on", "off"];
             }
             if (normalized === "board-type") {
                 return ["dgt", "certabo", "chesslink", "chessnut", "ichessone", "noeboard"];
@@ -338,40 +312,21 @@
             return (found.value || fallback).trim().toLowerCase();
         }
 
-        function bcSpeedChanged() {
-            var isManual = document.getElementById("bc-hint-speed").value === "manual";
-            document.getElementById("bc-manual-rows").style.display = isManual ? "" : "none";
-        }
-
         function updateBrainCoachSection(entries) {
             document.getElementById("bc-coach").value =
                 getIniValue(entries, "tutor-coach", "off");
-            var speed = getIniValue(entries, "tutor-brain-hint-speed", null);
-            var dur   = getIniValue(entries, "tutor-brain-hint-duration", "3");
-            var pause = getIniValue(entries, "tutor-brain-hint-pause", "2");
-            if (!speed || speed === "manual") {
-                // Manual mode: show individual inputs
-                document.getElementById("bc-hint-speed").value = "manual";
-                document.getElementById("bc-hint-duration").value = dur;
-                document.getElementById("bc-hint-pause").value = pause;
-            } else {
-                document.getElementById("bc-hint-speed").value = speed;
-            }
-            bcSpeedChanged();
+            document.getElementById("bc-hint-display").value =
+                getIniValue(entries, "tutor-brain-hint-display", "0");
+            document.getElementById("bc-reveal-text").value =
+                getIniValue(entries, "tutor-brain-reveal-text", "on");
         }
 
         function saveBrainCoachSettings() {
-            var speed = document.getElementById("bc-hint-speed").value;
             var entries = [
-                { key: "tutor-coach", value: document.getElementById("bc-coach").value, enabled: true },
+                { key: "tutor-coach",               value: document.getElementById("bc-coach").value,        enabled: true },
+                { key: "tutor-brain-hint-display",  value: document.getElementById("bc-hint-display").value, enabled: true },
+                { key: "tutor-brain-reveal-text",   value: document.getElementById("bc-reveal-text").value,  enabled: true },
             ];
-            if (speed === "manual") {
-                entries.push({ key: "tutor-brain-hint-speed",    value: "manual", enabled: true });
-                entries.push({ key: "tutor-brain-hint-duration", value: document.getElementById("bc-hint-duration").value, enabled: true });
-                entries.push({ key: "tutor-brain-hint-pause",    value: document.getElementById("bc-hint-pause").value,    enabled: true });
-            } else {
-                entries.push({ key: "tutor-brain-hint-speed", value: speed, enabled: true });
-            }
             setStatus("Saving BRAIN Coach settings...", false);
             fetch("/settings/save", {
                 method: "POST",


### PR DESCRIPTION
- Resolve picochess.py conflicts: keep tutor_analysis helpers and setpieces_switch_anchor_fen logic from handbrainfix
- Simplify hint config: replace hint-duration/pause/speed with single tutor-brain-hint-display (0=until user plays, 1-8=seconds)
- Add tutor-brain-reveal-text: show tutor move on DGT clock after user plays
- Fix TUTOR_MOVE_REVEAL timing: fire before think() so LED/text appear immediately when user plays, not when engine replies
- Remove clock-stop during BRAIN hint display; clock runs throughout
- Silence beep on BRAIN piece-type hint messages (play after every move)