### PR TITLE
Fix player name/ELO not updating in move list or display after webcli…

### DIFF
--- a/server.py
+++ b/server.py
@@ -954,6 +954,15 @@ class ChannelHandler(ServerRequestHandler):
                 self.shared["system_info"]["user_elo"] = str(elo_int)
                 write_picochess_ini("pgn-elo", str(elo_int))
                 logger.info("web set_player: elo=%r", elo_int)
+            # Broadcast the updated values to all connected webclient tabs so
+            # the move-list header and player display refresh immediately.
+            update = {}
+            if name:
+                update["user_name"] = name
+            if elo:
+                update["user_elo"] = str(elo_int)
+            if update:
+                EventHandler.write_to_clients({"event": "SystemInfo", "msg": update})
         elif action == "phone_speaker":
             enabled = self.get_argument("enabled", "false").lower() in ("1", "true", "yes", "on")
             self.shared["web_audio_backend_remote"] = enabled

--- a/web/picoweb/static/js/app.js
+++ b/web/picoweb/static/js/app.js
@@ -2906,6 +2906,34 @@ $(function () {
                         if (window.setTutorSettings && Object.prototype.hasOwnProperty.call(data.msg, 'tutor_watcher')) {
                             window.setTutorSettings(data.msg);
                         }
+                        // If the player name or ELO was updated, patch the PGN header
+                        // object and re-render the move list so the change is visible
+                        // immediately without waiting for the next game.
+                        if ('user_name' in data.msg || 'user_elo' in data.msg) {
+                            var _h = gameHistory.originalHeader;
+                            if (_h) {
+                                var _si = window._picoSystemInfo;
+                                var _newName = _si.user_name || '';
+                                var _newElo  = _si.user_elo  || '-';
+                                // play_mode is "user_white" or "user_black" — use it
+                                // directly so the correct PGN tag is always patched.
+                                if (_si.play_mode === 'user_black') {
+                                    if (_newName) { _h.Black    = _newName; }
+                                    _h.BlackElo = _newElo;
+                                } else {
+                                    // user_white or unknown — default to White
+                                    if (_newName) { _h.White    = _newName; }
+                                    _h.WhiteElo = _newElo;
+                                }
+                                gameHistory.gameHeader = getWebGameHeader(_h);
+                                var _pgnEl = document.getElementById('pgn');
+                                if (_pgnEl) {
+                                    var _exp = new WebExporter();
+                                    exportGame(gameHistory, _exp, true, true, undefined, false);
+                                    writeVariationTree(_pgnEl, _exp.toString(), gameHistory);
+                                }
+                            }
+                        }
                         if (window.chessground1) { updateChessGround(); }
                         if (window.syncClockControls) { window.syncClockControls(); }
                         break;


### PR DESCRIPTION
…ent change

server.py: broadcast a SystemInfo WebSocket event to all clients after set_player so connected tabs learn the new values immediately.

app.js: handle user_name / user_elo in the SystemInfo case by patching gameHistory.originalHeader and re-rendering the move-list PGN header, so the change is visible without starting a new game.