### PR TITLE
Fix issues with Chessnut Move

### DIFF
--- a/eboard/chessnut/command.py
+++ b/eboard/chessnut/command.py
@@ -105,11 +105,13 @@ def request_battery_status() -> bytes:
 def request_battery_status_chessnut_move() -> bytes:
     return b"\x41\x01\x0c"
 
+
 def query_files_count() -> bytes:
     # query files count to determine e-board type
     # query number of files of Chessnut Move (0x41, 0x01, 0x15) and regular Chessnut e-boards (0x31, 0x01, 0x00)
     # regular Chessnut e-boards only return one result, Chessnut Move e-boards return two results
     return b"\x41\x01\x15\x31\x01\x00"
+
 
 def _fen_to_board64(fen: str):
     """Convert piece-placement FEN to 64 nibbles in a1=0 order."""
@@ -140,7 +142,7 @@ def _encode_board(board64) -> bytes:
     return out
 
 
-def send_auto_move_fen(fen: str, uci_move: str) -> bytes:
+def send_auto_move_fen(fen: str, uci_move: str, is_reversed: bool) -> bytes:
     board = chess.Board(fen + " w KQkq - 0 1")
     move = chess.Move.from_uci(uci_move)
     if not board.is_legal(move):
@@ -151,6 +153,8 @@ def send_auto_move_fen(fen: str, uci_move: str) -> bytes:
 
     new_fen = board.board_fen()
     board64 = _fen_to_board64(new_fen)
+    if is_reversed:
+        board64 = board64[::-1]
     encoded = _encode_board(board64)
 
     cmd = bytearray(35)

--- a/eboard/chessnut/command.py
+++ b/eboard/chessnut/command.py
@@ -105,6 +105,11 @@ def request_battery_status() -> bytes:
 def request_battery_status_chessnut_move() -> bytes:
     return b"\x41\x01\x0c"
 
+def query_files_count() -> bytes:
+    # query files count to determine e-board type
+    # query number of files of Chessnut Move (0x41, 0x01, 0x15) and regular Chessnut e-boards (0x31, 0x01, 0x00)
+    # regular Chessnut e-boards only return one result, Chessnut Move e-boards return two results
+    return b"\x41\x01\x15\x31\x01\x00"
 
 def _fen_to_board64(fen: str):
     """Convert piece-placement FEN to 64 nibbles in a1=0 order."""

--- a/eboard/chessnut/command.py
+++ b/eboard/chessnut/command.py
@@ -142,11 +142,26 @@ def _encode_board(board64) -> bytes:
     return out
 
 
+def _get_ep_square(fen: str, uci_move: str) -> str:
+    board = chess.Board(fen)
+    pm = board.piece_map()
+    move = chess.Move.from_uci(uci_move)
+    if pm.get(move.from_square).piece_type != chess.PAWN or pm.get(move.to_square):
+        return "-"
+    if (chess.square_file(move.from_square) == chess.square_file(move.to_square)
+            or chess.square_rank(move.from_square) == chess.square_rank(move.to_square)):
+        return "-"
+    if chess.square_rank(move.to_square) not in (2, 5):
+        return "-"
+    return chess.square_name(move.to_square)
+
+
 def send_auto_move_fen(fen: str, uci_move: str, is_reversed: bool) -> bytes:
-    board = chess.Board(fen + " w KQkq - 0 1")
+    ep = _get_ep_square(fen, uci_move)
+    board = chess.Board(fen + " w KQkq " + ep + " 0 1")
     move = chess.Move.from_uci(uci_move)
     if not board.is_legal(move):
-        board = chess.Board(fen + " b KQkq - 0 1")
+        board = chess.Board(fen + " b KQkq " + ep + " 0 1")
         if not board.is_legal(move):
             return bytearray(0)
     board.push(move)

--- a/eboard/chessnut/parser.py
+++ b/eboard/chessnut/parser.py
@@ -67,15 +67,19 @@ class Parser(object):
                         value, battery = to_battery(data[i + 2], data[i + 3])
                         # Ignore invalid battery status (regular result from Chessnut Move)
                         if not (value == 0 and battery == Battery.EXHAUSTED):
-                            self.callback.board_type(BoardType.CHESSNUT_REGULAR)
                             self.callback.battery(value, battery)
                         i += 3
                     elif (i + 4) < len(data) and data[i] == 0x41 and data[i + 1] == 0x03 and data[i + 2] == 0x0C:
-                        self.callback.board_type(BoardType.CHESSNUT_MOVE)
                         value, battery = to_battery(data[i + 4], data[i + 3])
                         if not (value == 0 and battery == Battery.EXHAUSTED):
                             self.callback.battery(value, battery)
                         i += 4
+                    elif (i + 2) < len(data) and data[i] == 0x32 and data[i + 1] == 0x01:
+                        self.callback.board_type(BoardType.CHESSNUT_REGULAR)
+                        i += 2
+                    elif (i + 6) < len(data) and data[i] == 0x41 and data[i + 1] == 0x05 and data[i + 2] == 0x15:
+                        self.callback.board_type(BoardType.CHESSNUT_MOVE)
+                        i += 6
                 i += 1
         else:
             self._add_to_buffer(msg)

--- a/eboard/chessnut/protocol.py
+++ b/eboard/chessnut/protocol.py
@@ -274,4 +274,4 @@ class Protocol(ParserCallback):
         with self.board_mutex:
             fen = self.last_fen
         if fen is not None and self.connected and self.brd_type == BoardType.CHESSNUT_MOVE:
-            self.trans.write_mt(command.send_auto_move_fen(fen, uci_move))
+            self.trans.write_mt(command.send_auto_move_fen(fen, uci_move, self.brd_reversed))

--- a/eboard/chessnut/protocol.py
+++ b/eboard/chessnut/protocol.py
@@ -221,7 +221,8 @@ class Protocol(ParserCallback):
         self.brd_reversed = value
 
     def board_type(self, btype: BoardType):
-        if self.brd_type is None:
+        if (self.brd_type is None
+                or (self.brd_type == BoardType.CHESSNUT_REGULAR and btype == BoardType.CHESSNUT_MOVE)):
             self.brd_type = btype
 
     def set_led(self, pos):
@@ -247,9 +248,11 @@ class Protocol(ParserCallback):
 
     def request_battery_status(self):
         if self.connected:
-            if self.brd_type is None or self.brd_type == BoardType.CHESSNUT_REGULAR:
+            if self.brd_type is None:
+                self.trans.write_mt(command.query_files_count())
+            elif self.brd_type == BoardType.CHESSNUT_REGULAR:
                 self.trans.write_mt(command.request_battery_status())
-            if self.brd_type is None or self.brd_type == BoardType.CHESSNUT_MOVE:
+            elif self.brd_type == BoardType.CHESSNUT_MOVE:
                 self.trans.write_mt(command.request_battery_status_chessnut_move())
 
     def realtime_mode(self):

--- a/tests/test_chessnut_command.py
+++ b/tests/test_chessnut_command.py
@@ -72,8 +72,13 @@ class TestCommand(unittest.TestCase):
                          binascii.hexlify(arr))
 
     def test_send_auto_move_fen(self):
-        arr = cmd.send_auto_move_fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR", "e2e4")
+        arr = cmd.send_auto_move_fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR", "e2e4", False)
         self.assertEqual(b"422158233185444444440000000000000000007000000000000077077777a6c99b6a00",
+                         binascii.hexlify(arr))
+
+    def test_send_auto_move_fen_reversed(self):
+        arr = cmd.send_auto_move_fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR", "e2e4", True)
+        self.assertEqual(b"4221a6b99c6a7777707700000000000007000000000000000000444444445813328500",
                          binascii.hexlify(arr))
 
 

--- a/tests/test_chessnut_command.py
+++ b/tests/test_chessnut_command.py
@@ -81,6 +81,16 @@ class TestCommand(unittest.TestCase):
         self.assertEqual(b"4221a6b99c6a7777707700000000000007000000000000000000444444445813328500",
                          binascii.hexlify(arr))
 
+    def test_send_auto_move_fen_white_en_passant(self):
+        arr = cmd.send_auto_move_fen("rnbqkbnr/ppp2ppp/4p3/3pP3/8/8/PPPP1PPP/RNBQKBNR", "e5d6", False)
+        self.assertIsNotNone(arr)
+        self.assertEqual(35, len(arr))
+
+    def test_send_auto_move_fen_black_en_passant(self):
+        arr = cmd.send_auto_move_fen("rnbqkbnr/pppp1ppp/8/8/3Pp3/1P4P1/P1P1PP1P/RNBQKBNR", "e4d3", False)
+        self.assertIsNotNone(arr)
+        self.assertEqual(35, len(arr))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This pull request fixes two issues with the Chessnut Move implementation:

1. One user had an issue with detection of the Chessnut Move. Instead of the battery level, the number of offline games is queried for both Chessnut board types. The regular Chessnut e-boards return one result, the Chessnut Move returns two results. This should improve board type detection.
2. send_auto_move_fen is extended to also support reverse board setups (White at ranks 7+8, Black at ranks 1+2).