### PR TITLE
Normalize native PicoTalker volume with ReplayGain

### DIFF
--- a/picotalker.py
+++ b/picotalker.py
@@ -27,6 +27,7 @@ from collections import OrderedDict
 import subprocess
 import signal
 import threading
+import re
 from typing import Callable, Optional
 
 try:
@@ -52,6 +53,7 @@ SOUND_CACHE_LIMIT = 128
 NATIVE_STREAM_STARTUP_WAIT = 0.3
 SOX_PLAY_TIMEOUT = 12.0
 SOX_PLAY_KILL_TIMEOUT = 1.0
+REPLAYGAIN_TRACK_GAIN_RE = re.compile(rb"REPLAYGAIN_TRACK_GAIN=([+-]?\d+(?:\.\d+)?)\s*dB", re.IGNORECASE)
 
 
 class PicoTalker(object):
@@ -373,6 +375,37 @@ class PicoTalkerDisplay(DisplayMsg):
         tsm.run(reader, writer)
         return writer.data.T
 
+    @staticmethod
+    def _read_replaygain_track_gain(voice_file: str) -> Optional[float]:
+        try:
+            data = Path(voice_file).read_bytes()
+        except OSError as exc:
+            logger.debug("ReplayGain read failed for %s: %s", voice_file, exc)
+            return None
+
+        match = REPLAYGAIN_TRACK_GAIN_RE.search(data)
+        if not match:
+            return None
+        try:
+            return float(match.group(1).decode("ascii"))
+        except ValueError:
+            return None
+
+    @staticmethod
+    def _apply_replaygain_track_gain(samples, gain_db: Optional[float]):
+        if gain_db is None or gain_db == 0:
+            return samples
+        if samples.size == 0:
+            return samples
+
+        gain = 10 ** (gain_db / 20)
+        peak = float(np.max(np.abs(samples)))
+        if peak > 0:
+            gain = min(gain, 1.0 / peak)
+        if gain == 1.0:
+            return samples
+        return samples * np.float32(gain)
+
     def native_sound_player(self, voice_file) -> bool:
         """Speak out the sound part using native Python audio stack."""
         if not NATIVE_AUDIO_AVAILABLE:
@@ -384,6 +417,7 @@ class PicoTalkerDisplay(DisplayMsg):
                 samples, samplerate = sf.read(voice_file, dtype="float32", always_2d=True)
                 if self.speed_factor != 1.0:
                     samples = self._audiotsm_process(samples)
+                samples = self._apply_replaygain_track_gain(samples, self._read_replaygain_track_gain(voice_file))
                 self._sound_cache_put(key, (samples, samplerate))
             else:
                 samples, samplerate = cached

--- a/tests/test_picotalker.py
+++ b/tests/test_picotalker.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python3
 
 import subprocess
+import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import Mock, patch
+
+import numpy as np
 
 from picotalker import PicoTalkerDisplay
 
@@ -48,6 +52,49 @@ class TestPicoTalkerSoxBackend(unittest.TestCase):
         self.assertFalse(played)
         killpg_mock.assert_called_once()
         self.assertEqual(process.wait.call_count, 2)
+
+
+class TestPicoTalkerReplayGain(unittest.TestCase):
+    def test_read_replaygain_track_gain_from_ogg_comment_bytes(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            voice_file = Path(tmpdir) / "voice.ogg"
+            voice_file.write_bytes(b"OggS\x00REPLAYGAIN_TRACK_GAIN=+2.62 dB\x00Vorbis")
+
+            gain = PicoTalkerDisplay._read_replaygain_track_gain(str(voice_file))
+
+        self.assertEqual(gain, 2.62)
+
+    def test_read_replaygain_track_gain_returns_none_when_missing(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            voice_file = Path(tmpdir) / "voice.ogg"
+            voice_file.write_bytes(b"OggS\x00TITLE=check\x00Vorbis")
+
+            gain = PicoTalkerDisplay._read_replaygain_track_gain(str(voice_file))
+
+        self.assertIsNone(gain)
+
+    def test_apply_replaygain_track_gain_scales_samples(self):
+        samples = np.array([[0.25], [-0.25]], dtype=np.float32)
+
+        adjusted = PicoTalkerDisplay._apply_replaygain_track_gain(samples, 6.0)
+
+        self.assertAlmostEqual(float(adjusted[0, 0]), 0.25 * (10 ** (6.0 / 20)), places=6)
+        self.assertAlmostEqual(float(adjusted[1, 0]), -0.25 * (10 ** (6.0 / 20)), places=6)
+
+    def test_apply_replaygain_track_gain_limits_positive_gain_to_prevent_clipping(self):
+        samples = np.array([[0.8], [-0.4]], dtype=np.float32)
+
+        adjusted = PicoTalkerDisplay._apply_replaygain_track_gain(samples, 6.0)
+
+        self.assertAlmostEqual(float(np.max(np.abs(adjusted))), 1.0, places=6)
+        self.assertAlmostEqual(float(adjusted[1, 0]), -0.5, places=6)
+
+    def test_apply_replaygain_track_gain_leaves_untagged_samples_unchanged(self):
+        samples = np.array([[0.25], [-0.25]], dtype=np.float32)
+
+        adjusted = PicoTalkerDisplay._apply_replaygain_track_gain(samples, None)
+
+        self.assertIs(adjusted, samples)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Apply embedded ReplayGain track metadata during native audio playback so voice clips with different recorded amplitudes play at more consistent loudness. This brings native playback closer to the existing SoX behavior while leaving untagged clips unchanged.