### PR TITLE
412 Improve ANALYSES tab space usage for small screens

### DIFF
--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -155,6 +155,26 @@ explicitly requires it.
 - Do not start or restart browser Stockfish from position updates unless the Web
   analysis toggle is active.
 
+## ANALYSES Tab SHOW/HIDE State
+
+- Treat the ANALYSES tab row visibility as shared UI state, not as independent
+  CSS tweaks. The Pico backend row, Web Stockfish row, separator, and
+  `#right-panel` sizing classes must stay synchronized.
+- Use the existing row helpers in `web/picoweb/static/js/app.js`:
+  `setAnalysisRowVisible()`, `updateAnalysisRowSeparator()`,
+  `setEngineLinePlaceholder()`, and `setSF18Placeholder()`.
+- Do not hide or show `#engineRow`, `#sf18Row`, or `#analysisRowSeparator`
+  directly with ad hoc jQuery/CSS unless those helpers are also updated.
+- When a row is hidden, also clear its stale content and reset its button text
+  to `SHOW`. When a row is shown by fresh data or by an explicit user click, set
+  the corresponding button text to `HIDE`.
+- Keep `analysis-rows-none`, `analysis-rows-one`, and `analysis-rows-two` on
+  `#right-panel` as the single source for letting the PGN move list reclaim
+  space when analysis rows are collapsed.
+- The Web Stockfish SHOW/HIDE button also controls browser CPU usage. Hiding Web
+  analysis must call the path that stops the browser Stockfish worker/module; it
+  must not merely hide the DOM row.
+
 ## System Audio Design
 
 - There are two web audio sources:

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -142,6 +142,19 @@ explicitly requires it.
 - Read and display backend tutor state when the web client opens, and keep it in
   sync via websocket updates.
 
+## ANALYSES Tab CPU
+
+- The web-client Stockfish row is browser-side analysis and is separate from
+  Picochess backend analysis.
+- On localhost, only one web-client Stockfish analysis line may run, and hiding
+  the Web row must stop the browser Stockfish worker/module so it does not
+  compete with the Picochess service for CPU.
+- Remote web clients may expose multiple Web Stockfish MultiPV rows, but hiding
+  Web analysis should still stop browser Stockfish rather than only hiding its
+  output.
+- Do not start or restart browser Stockfish from position updates unless the Web
+  analysis toggle is active.
+
 ## System Audio Design
 
 - There are two web audio sources:

--- a/web/picoweb/static/css/base.css
+++ b/web/picoweb/static/css/base.css
@@ -1418,13 +1418,13 @@ piece {
 
 @media (min-width: 1000px) and (max-width: 1100px) and (max-height: 770px) {
     #row-movelist {
-        flex: 0 1 128px;
-        max-height: 128px;
+        flex: 0 1 220px;
+        max-height: 220px;
     }
 
     #row-tabs {
         flex: 1 1 0;
-        min-height: 320px;
+        min-height: 230px;
     }
 
     #data {
@@ -1432,7 +1432,7 @@ piece {
     }
 
     #data.card {
-        min-height: 320px;
+        min-height: 230px;
     }
 
     #data .card-header {

--- a/web/picoweb/static/css/base.css
+++ b/web/picoweb/static/css/base.css
@@ -791,6 +791,10 @@ td.result {
     padding: 0.35rem 0.5rem;
 }
 
+.analysis-row-collapsed {
+    display: none !important;
+}
+
 .pv-header {
     display: flex;
     flex-direction: row;
@@ -1449,9 +1453,49 @@ piece {
         margin-bottom: 2px;
     }
 
+    #right-panel.analysis-rows-none #row-movelist,
+    #right-panel.analysis-rows-one #row-movelist {
+        flex: 1 1 auto;
+        max-height: none;
+    }
+
+    #right-panel.analysis-rows-none #row-tabs {
+        flex: 0 0 auto;
+        min-height: 0;
+    }
+
+    #right-panel.analysis-rows-one #row-tabs {
+        flex: 0 0 auto;
+        min-height: 145px;
+    }
+
+    #right-panel.analysis-rows-none #data.card,
+    #right-panel.analysis-rows-one #data.card {
+        min-height: 0;
+    }
+
+    #right-panel.analysis-rows-none #row-tabs .card,
+    #right-panel.analysis-rows-one #row-tabs .card {
+        flex: 0 0 auto;
+    }
+
+    #right-panel.analysis-rows-none #data .card-body,
+    #right-panel.analysis-rows-one #data .card-body,
+    #right-panel.analysis-rows-none #data .tab-content,
+    #right-panel.analysis-rows-one #data .tab-content,
+    #right-panel.analysis-rows-none #data .tab-pane,
+    #right-panel.analysis-rows-one #data .tab-pane {
+        height: auto !important;
+    }
+
     .scroll_engine {
         max-height: none;
         height: 100%;
+    }
+
+    #right-panel.analysis-rows-none .scroll_engine,
+    #right-panel.analysis-rows-one .scroll_engine {
+        height: auto;
     }
 
     .analysis-toolbar {

--- a/web/picoweb/static/css/base.css
+++ b/web/picoweb/static/css/base.css
@@ -783,6 +783,11 @@ td.result {
     min-width: 0;
 }
 
+#sf18Pv1Body > .pv-extra-line {
+    padding-left: 0;
+    padding-right: 0;
+}
+
 /* Two-row PV item layout (server engine + SF18) */
 .pv-two-row {
     display: flex;

--- a/web/picoweb/static/css/base.css
+++ b/web/picoweb/static/css/base.css
@@ -266,6 +266,7 @@ div.dataTables_wrapper div.dataTables_length select {
 
 #data {
     margin-top: 10px;
+    width: 100%;
 }
 
 /* Igualar altura de columnas - Sistema responsive universal */
@@ -795,6 +796,7 @@ td.result {
     align-items: center;
     gap: 0.35rem;
     flex-wrap: nowrap;
+    min-width: 0;
 }
 
 .pv-body {
@@ -802,7 +804,8 @@ td.result {
     flex-direction: row;
     align-items: baseline;
     gap: 0.3rem;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
+    min-width: 0;
 }
 
 /* Engine / source name — plain bold label, no pill */
@@ -812,7 +815,10 @@ td.result {
     font-weight: 600;
     color: var(--bs-body-color, #212529);
     white-space: nowrap;
-    flex-shrink: 0;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    flex: 0 1 auto;
 }
 
 .backend-source-badge {
@@ -838,6 +844,37 @@ td.result {
 /* Rubber spacer: pushes buttons to the right in pv-header */
 .pv-spacer {
     flex: 1;
+}
+
+.analysis-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+    padding: 0.25rem 0.5rem 0.35rem;
+    margin-bottom: 0.15rem;
+    border-bottom: 1px solid rgba(var(--bs-body-color-rgb, 33, 37, 41), 0.14);
+}
+
+.analysis-control-set {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    min-width: 0;
+}
+
+.analysis-control-label {
+    color: var(--bs-secondary-color, #6c757d);
+    font-size: 0.8rem;
+    font-weight: 700;
+    line-height: 1;
+    white-space: nowrap;
+}
+
+.analysis-toolbar-btn,
+.analysis-toolbar .book-switch-btn {
+    min-height: 36px;
+    touch-action: manipulation;
 }
 
 /* Small move-number label in server analysis header */
@@ -1335,11 +1372,11 @@ piece {
 }
 
 #row-clock   { flex: 0 0 auto; }
-#row-tabs    { flex: 1 1 35%; min-height: 0; display: flex; flex-direction: column; }
+#row-tabs    { flex: 1.35 1 48%; min-height: 0; display: flex; flex-direction: column; }
 #row-remote  { flex: 0 0 auto; }
 
 #row-movelist {
-    flex: 1 1 40%;
+    flex: 0.8 1 30%;
     min-height: 0;
     display: flex;
     flex-direction: column;
@@ -1377,6 +1414,82 @@ piece {
 #row-tabs .tab-pane.show.active {
     height: 100%;
     overflow-y: auto;
+}
+
+@media (min-width: 1000px) and (max-width: 1100px) and (max-height: 770px) {
+    #row-movelist {
+        flex: 0 1 128px;
+        max-height: 128px;
+    }
+
+    #row-tabs {
+        flex: 1 1 0;
+        min-height: 320px;
+    }
+
+    #data {
+        margin-top: 2px;
+    }
+
+    #data.card {
+        min-height: 320px;
+    }
+
+    #data .card-header {
+        padding: 3px;
+    }
+
+    #data .card-body {
+        padding: 4px 5px;
+    }
+
+    #row-movelist .scroll_movelist {
+        margin-top: 2px;
+        margin-bottom: 2px;
+    }
+
+    .scroll_engine {
+        max-height: none;
+        height: 100%;
+    }
+
+    .analysis-toolbar {
+        padding: 0.2rem 0.35rem 0.25rem;
+        gap: 0.3rem;
+    }
+
+    .analysis-toolbar-btn,
+    .analysis-toolbar .book-switch-btn {
+        min-height: 34px;
+        padding: 0.25rem 0.5rem;
+    }
+
+    .pv-two-row {
+        padding: 0.25rem 0.35rem;
+        gap: 0.15rem;
+    }
+
+    .pv-header {
+        gap: 0.25rem;
+    }
+
+    #engineRow .score-display,
+    #sf18Row .score-display,
+    #pv_output .score-display,
+    #engineRow .depth-display,
+    #sf18Row .depth-display,
+    #pv_output .depth-display {
+        font-size: 0.88rem;
+    }
+
+    #engineRow .first-move,
+    #sf18Row .first-move,
+    #pv_output .first-move,
+    #engineRow .continuation-moves,
+    #sf18Row .continuation-moves,
+    #pv_output .continuation-moves {
+        font-size: 1rem;
+    }
 }
 
 /* ── PICO CONTEXT MENU OVERLAY ─────────────────────────────── */
@@ -1950,7 +2063,25 @@ html[data-theme="dark"] .analysis-sources .first-move {
 }
 
 html[data-theme="dark"] .engine-name-badge {
-    color: var(--bs-body-color, #dee2e6);
+    color: #dee2e6 !important;
+}
+
+html[data-theme="dark"] .backend-source-badge {
+    border-color: rgba(255, 255, 255, 0.35);
+    color: #f1f3f5;
+}
+
+html[data-theme="dark"] .backend-source-badge.tutor-source {
+    border-color: rgba(139, 171, 224, 0.75);
+    color: #9ec5fe;
+}
+
+html[data-theme="dark"] .analysis-toolbar {
+    border-bottom-color: rgba(255, 255, 255, 0.18);
+}
+
+html[data-theme="dark"] .analysis-control-label {
+    color: rgba(255, 255, 255, 0.72);
 }
 
 html[data-theme="dark"] #pico-footer {

--- a/web/picoweb/static/css/base.css
+++ b/web/picoweb/static/css/base.css
@@ -1206,6 +1206,14 @@ piece {
     touch-action: manipulation;
 }
 
+@media (min-width: 769px) and (orientation: landscape) {
+    .clock-control-main .pico-clock-action {
+        width: 4rem;
+        height: 2.85rem;
+        font-size: 1.25rem;
+    }
+}
+
 @media (max-width: 768px) and (orientation: portrait) {
     html.is-remote-web-client .clock-control-row {
         grid-template-columns: minmax(0, 1fr) auto;

--- a/web/picoweb/static/css/base.css
+++ b/web/picoweb/static/css/base.css
@@ -879,7 +879,39 @@ td.result {
 .analysis-toolbar-btn,
 .analysis-toolbar .book-switch-btn {
     min-height: 36px;
+    padding-left: 0.45rem;
+    padding-right: 0.45rem;
     touch-action: manipulation;
+}
+
+#tutorWatchBtn.analysis-toolbar-btn {
+    min-width: 48px;
+}
+
+@media (max-width: 480px) {
+    .analysis-toolbar {
+        gap: 0.25rem;
+        padding-left: 0.35rem;
+        padding-right: 0.35rem;
+    }
+
+    .analysis-control-set {
+        gap: 0.18rem;
+    }
+
+    .analysis-control-label {
+        font-size: 0.75rem;
+    }
+
+    .analysis-toolbar-btn,
+    .analysis-toolbar .book-switch-btn {
+        padding-left: 0.35rem;
+        padding-right: 0.35rem;
+    }
+
+    #tutorWatchBtn.analysis-toolbar-btn {
+        min-width: 44px;
+    }
 }
 
 /* Small move-number label in server analysis header */

--- a/web/picoweb/static/css/base.css
+++ b/web/picoweb/static/css/base.css
@@ -776,10 +776,11 @@ td.result {
 .pv-extra-line {
     display: flex;
     flex-direction: row;
-    align-items: center;
+    align-items: baseline;
     gap: 0.35rem;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     padding: 0.15rem 0.5rem;
+    min-width: 0;
 }
 
 /* Two-row PV item layout (server engine + SF18) */

--- a/web/picoweb/static/css/base.css
+++ b/web/picoweb/static/css/base.css
@@ -1201,6 +1201,21 @@ piece {
     touch-action: manipulation;
 }
 
+@media (max-width: 768px) and (orientation: portrait) {
+    html.is-remote-web-client .clock-control-row {
+        grid-template-columns: minmax(0, 1fr) auto;
+    }
+
+    html.is-remote-web-client .clock-control-spacer {
+        display: none;
+    }
+
+    html.is-remote-web-client .clock-control-main {
+        justify-content: flex-start;
+        min-width: 0;
+    }
+}
+
 .pico-clock-action:hover,
 .pico-clock-action:focus-visible {
     background: rgba(128, 128, 128, 0.16);

--- a/web/picoweb/static/js/app.js
+++ b/web/picoweb/static/js/app.js
@@ -1830,6 +1830,7 @@ function handleMessage(event) {
     var output = formatEngineOutput(event.data);
     if (output && output.pv_index === 1) {
         // Update the static SF18 first-PV row
+        setAnalysisRowVisible('sf18Row', true);
         var metaEl = document.getElementById('sf18Meta');
         var bodyEl = document.getElementById('sf18Pv1Body');
         if (metaEl) metaEl.innerHTML = output.meta || '';
@@ -1917,6 +1918,7 @@ function analyze(position_update) {
     if (!position_update) {
         if (!window.analysis) {
             window.analysis = true;
+            setAnalysisRowVisible('sf18Row', true);
             var sf18Btn = document.getElementById('sf18ToggleBtn');
             if (sf18Btn) sf18Btn.textContent = 'HIDE';
             updateSF18PmButtons();
@@ -2236,6 +2238,7 @@ function updateBackendAnalysisLine(analysis) {
         setEngineLinePlaceholder();
         return;
     }
+    setAnalysisRowVisible('engineRow', true);
     updateBackendAnalysisSourceBadge(analysis.source);
     var scoreText = '?';
     if (analysis.mate) {
@@ -2362,6 +2365,30 @@ function updateAnalysisClock(analysis) {
     if (line) dgtClockTextEl.html(line);
 }
 
+function setAnalysisRowVisible(rowId, visible) {
+    var row = document.getElementById(rowId);
+    if (row) row.classList.toggle('analysis-row-collapsed', !visible);
+    updateAnalysisRowSeparator();
+}
+
+function updateAnalysisRowSeparator() {
+    var separator = document.getElementById('analysisRowSeparator');
+    var engineRow = document.getElementById('engineRow');
+    var sf18Row = document.getElementById('sf18Row');
+    var rightPanel = document.getElementById('right-panel');
+    if (!separator || !engineRow || !sf18Row) return;
+    var engineVisible = !engineRow.classList.contains('analysis-row-collapsed');
+    var sf18Visible = !sf18Row.classList.contains('analysis-row-collapsed');
+    var visibleRows = (engineVisible ? 1 : 0) + (sf18Visible ? 1 : 0);
+    var bothVisible = visibleRows === 2;
+    separator.classList.toggle('analysis-row-collapsed', !bothVisible);
+    if (rightPanel) {
+        rightPanel.classList.toggle('analysis-rows-none', visibleRows === 0);
+        rightPanel.classList.toggle('analysis-rows-one', visibleRows === 1);
+        rightPanel.classList.toggle('analysis-rows-two', visibleRows === 2);
+    }
+}
+
 // Clear engine analysis content; reset button to SHOW.
 function setEngineLinePlaceholder() {
     var metaEl = document.getElementById('engineMeta');
@@ -2370,6 +2397,7 @@ function setEngineLinePlaceholder() {
     if (metaEl) metaEl.innerHTML = '';
     if (bodyEl) bodyEl.innerHTML = '';
     if (btn)    btn.textContent = 'SHOW';
+    setAnalysisRowVisible('engineRow', false);
 }
 
 function updateBackendAnalysisSourceBadge(source) {
@@ -2408,6 +2436,7 @@ function setSF18Placeholder() {
     if (metaEl) metaEl.innerHTML = '';
     if (bodyEl) bodyEl.innerHTML = '';
     if (btn)    btn.textContent = 'SHOW';
+    setAnalysisRowVisible('sf18Row', false);
     // Clear extra PV lines
     $('#pv_output').empty();
     updateSF18PmButtons();
@@ -3011,6 +3040,7 @@ $(function () {
                 updateBackendAnalysisLine(lastServerAnalysis);
             } else {
                 // No data yet — show HIDE so user knows it's active
+                setAnalysisRowVisible('engineRow', true);
                 var btn = document.getElementById('engineToggleBtn');
                 if (btn) btn.textContent = 'HIDE';
             }

--- a/web/picoweb/static/js/app.js
+++ b/web/picoweb/static/js/app.js
@@ -55,6 +55,8 @@ function isLocalWebClient() {
 
 function updateWebAudioMuteButtonVisibility() {
     const isRemoteClient = !isLocalWebClient();
+    document.documentElement.classList.toggle('is-remote-web-client', isRemoteClient);
+    document.documentElement.classList.toggle('is-local-web-client', !isRemoteClient);
     const pgnActions = $('#clockPgnActions');
     if (isRemoteClient) {
         pgnActions.addClass('is-visible').css('display', '');

--- a/web/picoweb/static/js/app.js
+++ b/web/picoweb/static/js/app.js
@@ -1631,12 +1631,14 @@ function formatEngineOutput(line) {
             scoreClass += ' score-negative';
         }
 
-        // Build score+depth meta HTML (shared for pv_1 update and pv_2+ header)
-        var metaHtml = '';
+        // Build score/depth meta HTML. The first Web line shows the depth; extra
+        // MultiPV lines omit it because all Web lines are from the same search.
+        var scoreHtml = '';
         if (score !== null) {
-            metaHtml += '<span class="' + scoreClass + '">' + score + '</span>';
+            scoreHtml = '<span class="' + scoreClass + '">' + score + '</span>';
         }
-        metaHtml += '<span class="depth-display">d' + depth + '</span>';
+        var depthHtml = '<span class="depth-display">d' + depth + '</span>';
+        var metaHtml = scoreHtml + depthHtml;
 
         // Build PV body HTML
         var bodyHtml = '';
@@ -1677,13 +1679,11 @@ function formatEngineOutput(line) {
             return { meta: metaHtml, body: bodyHtml, pv_index: 1 };
         }
 
-        // Extra PV lines (pv_2+): same two-row layout as pv_1 but without buttons
-        output = '<div class="pv-two-row">';
-        output += '<div class="pv-header">';
-        output += '<span class="engine-name-badge">Web client Stockfish 18</span>';
-        output += metaHtml;
-        output += '</div>';
-        output += '<div class="pv-body">' + bodyHtml + '</div>';
+        // Extra PV lines (pv_2+): keep them compact and avoid repeating the
+        // Web source headline or depth badge for every MultiPV result.
+        output = '<div class="pv-extra-line">';
+        output += scoreHtml;
+        output += bodyHtml;
         output += '</div>';
         return { line: output, pv_index: multipv };
     }

--- a/web/picoweb/static/js/app.js
+++ b/web/picoweb/static/js/app.js
@@ -1633,14 +1633,13 @@ function formatEngineOutput(line) {
             scoreClass += ' score-negative';
         }
 
-        // Build score/depth meta HTML. The first Web line shows the depth; extra
-        // MultiPV lines omit it because all Web lines are from the same search.
+        // Build score/depth HTML. The Web header shows depth once; every PV line
+        // uses the same compact score + move layout.
         var scoreHtml = '';
         if (score !== null) {
             scoreHtml = '<span class="' + scoreClass + '">' + score + '</span>';
         }
         var depthHtml = '<span class="depth-display">d' + depth + '</span>';
-        var metaHtml = scoreHtml + depthHtml;
 
         // Build PV body HTML
         var bodyHtml = '';
@@ -1675,18 +1674,16 @@ function formatEngineOutput(line) {
 
         analysis_game = null;
 
-        if (multipv === 1) {
-            // First PV: update the static SF18 row elements directly
-            updateEvaluationBar(score);
-            return { meta: metaHtml, body: bodyHtml, pv_index: 1 };
-        }
-
-        // Extra PV lines (pv_2+): keep them compact and avoid repeating the
-        // Web source headline or depth badge for every MultiPV result.
+        // Keep all Web PV lines compact and avoid repeating the Web source
+        // headline or depth badge for every MultiPV result.
         output = '<div class="pv-extra-line">';
         output += scoreHtml;
         output += bodyHtml;
         output += '</div>';
+        if (multipv === 1) {
+            updateEvaluationBar(score);
+            return { meta: depthHtml, line: output, pv_index: 1 };
+        }
         return { line: output, pv_index: multipv };
     }
     else if (line.search('currmove') < 0 && line.search('time') < 0) {
@@ -1803,7 +1800,7 @@ function analyzePressed() {
         $('#evaluationBar').css('visibility', 'visible');
     } else {
         $('#evaluationBar').css('visibility', 'hidden');
-        // Clear extra PV lines; pv_1 body is static HTML in sf18Row
+        // Clear extra PV containers; pv_1 lives in the static SF18 row.
         $('#pv_output').empty();
         for (var i = 2; i <= window.multipv; i++) {
             $('#pv_output').append('<div id="pv_' + i + '" class="pv-container"></div>');
@@ -1831,12 +1828,13 @@ function handleMessage(event) {
     if (!event || !event.data) return;
     var output = formatEngineOutput(event.data);
     if (output && output.pv_index === 1) {
-        // Update the static SF18 first-PV row
+        // Update the static SF18 first-PV row with the same compact PV layout
+        // used for additional Web MultiPV rows.
         setAnalysisRowVisible('sf18Row', true);
         var metaEl = document.getElementById('sf18Meta');
         var bodyEl = document.getElementById('sf18Pv1Body');
         if (metaEl) metaEl.innerHTML = output.meta || '';
-        if (bodyEl) bodyEl.innerHTML = output.body || '';
+        if (bodyEl) bodyEl.innerHTML = output.line || '';
     } else if (output && output.pv_index > 1) {
         $('#pv_' + output.pv_index).html(output.line);
     }

--- a/web/picoweb/templates/clock.html
+++ b/web/picoweb/templates/clock.html
@@ -667,7 +667,7 @@
                         <div id="menuButtons" style="display:none;"></div>
 
                         <!-- ── MOVE LIST ─────────────────────────────────── -->
-                        <div class="row flex-grow-1 min-h-0" id="row-movelist">
+                        <div class="row min-h-0" id="row-movelist">
                             <div class="card h-100">
                                 <div class="scroll_movelist h-100" id="moveList">
                                     <div class="card-body">
@@ -677,7 +677,7 @@
                             </div>
                         </div>
 
-                        <div class="row">
+                        <div class="row min-h-0" id="row-tabs">
                             <div id="data" class="card">
                                 <div class="card-header">
                                     <div style="display: flex; justify-content: space-between; align-items: center;">
@@ -723,17 +723,34 @@
                                                 </div>
                                                 <div id="engineStatus"></div>
 
+                                                <div class="analysis-toolbar" aria-label="Analysis controls">
+                                                    <button type="button" id="tutorWatchBtn" class="btn btn-sm btn-outline-primary analysis-toolbar-btn" title="Toggle Tutor analysis/watch" aria-label="Toggle Tutor analysis/watch">
+                                                        <i class="fa fa-eye-slash" aria-hidden="true"></i><span>Tutor</span>
+                                                    </button>
+                                                    <span class="analysis-control-set">
+                                                        <span class="analysis-control-label">Pico</span>
+                                                        <button id="engineToggleBtn" class="btn btn-sm btn-primary analysis-toolbar-btn">SHOW</button>
+                                                    </span>
+                                                    <span class="analysis-control-set">
+                                                        <span class="analysis-control-label">Web</span>
+                                                        <span class="btn-group btn-group-xs" id="sf18PmGroup" style="display:none">
+                                                            <button id="analyzeMinus" class="btn btn-sm btn-primary book-switch-btn" aria-label="Fewer lines">
+                                                                <i class="fa fa-minus" aria-hidden="true"></i>
+                                                            </button>
+                                                            <button id="analyzePlus" class="btn btn-sm btn-primary book-switch-btn" aria-label="More lines">
+                                                                <i class="fa fa-plus" aria-hidden="true"></i>
+                                                            </button>
+                                                        </span>
+                                                        <button id="sf18ToggleBtn" class="btn btn-sm btn-primary analysis-toolbar-btn">SHOW</button>
+                                                    </span>
+                                                </div>
+
                                                 <!-- Server engine analysis (static structure, JS updates content) -->
                                                 <div class="pv-two-row" id="engineRow" aria-live="polite">
                                                     <div class="pv-header">
                                                         <span class="engine-name-badge" id="engineNameBadge">Pico</span>
                                                         <span class="backend-source-badge engine-source" id="backendAnalysisSourceBadge" title="Pico backend analysis source: selected engine">E</span>
-                                                        <button type="button" id="tutorWatchBtn" class="btn btn-sm btn-outline-primary" title="Toggle Tutor analysis/watch" aria-label="Toggle Tutor analysis/watch">
-                                                            <i class="fa fa-eye-slash" aria-hidden="true"></i><span>Tutor</span>
-                                                        </button>
                                                         <div id="engineMeta"></div>
-                                                        <div class="pv-spacer"></div>
-                                                        <button id="engineToggleBtn" class="btn btn-sm btn-primary">SHOW</button>
                                                     </div>
                                                     <div id="enginePvBody" class="pv-body"></div>
                                                 </div>
@@ -743,18 +760,8 @@
                                                 <!-- SF18 analysis (static header, JS updates content + extra PVs) -->
                                                 <div class="pv-two-row" id="sf18Row">
                                                     <div class="pv-header">
-                                                        <span class="engine-name-badge">Web client Stockfish 18</span>
+                                                        <span class="engine-name-badge" title="Web client Stockfish 18">Web Stockfish 18</span>
                                                         <div id="sf18Meta"></div>
-                                                        <div class="pv-spacer"></div>
-                                                        <div class="btn-group btn-group-xs" id="sf18PmGroup" style="display:none">
-                                                            <button id="analyzeMinus" class="btn btn-sm btn-primary book-switch-btn" aria-label="Fewer lines">
-                                                                <i class="fa fa-minus" aria-hidden="true"></i>
-                                                            </button>
-                                                            <button id="analyzePlus" class="btn btn-sm btn-primary book-switch-btn" aria-label="More lines">
-                                                                <i class="fa fa-plus" aria-hidden="true"></i>
-                                                            </button>
-                                                        </div>
-                                                        <button id="sf18ToggleBtn" class="btn btn-sm btn-primary">SHOW</button>
                                                     </div>
                                                     <div id="sf18Pv1Body" class="pv-body"></div>
                                                 </div>

--- a/web/picoweb/templates/clock.html
+++ b/web/picoweb/templates/clock.html
@@ -763,7 +763,7 @@
                                                         <span class="engine-name-badge" title="Web client Stockfish 18">Web</span>
                                                         <div id="sf18Meta"></div>
                                                     </div>
-                                                    <div id="sf18Pv1Body" class="pv-body"></div>
+                                                    <div id="sf18Pv1Body" class="pv-container"></div>
                                                 </div>
                                                 <!-- Extra SF18 PV lines (pv_2, pv_3 ...) -->
                                                 <div id="pv_output"></div>

--- a/web/picoweb/templates/clock.html
+++ b/web/picoweb/templates/clock.html
@@ -760,7 +760,7 @@
                                                 <!-- SF18 analysis (static header, JS updates content + extra PVs) -->
                                                 <div class="pv-two-row" id="sf18Row">
                                                     <div class="pv-header">
-                                                        <span class="engine-name-badge" title="Web client Stockfish 18">Web Stockfish 18</span>
+                                                        <span class="engine-name-badge" title="Web client Stockfish 18">Web</span>
                                                         <div id="sf18Meta"></div>
                                                     </div>
                                                     <div id="sf18Pv1Body" class="pv-body"></div>

--- a/web/picoweb/templates/clock.html
+++ b/web/picoweb/templates/clock.html
@@ -725,7 +725,7 @@
 
                                                 <div class="analysis-toolbar" aria-label="Analysis controls">
                                                     <button type="button" id="tutorWatchBtn" class="btn btn-sm btn-outline-primary analysis-toolbar-btn" title="Toggle Tutor analysis/watch" aria-label="Toggle Tutor analysis/watch">
-                                                        <i class="fa fa-eye-slash" aria-hidden="true"></i><span>Tutor</span>
+                                                        <i class="fa fa-eye-slash" aria-hidden="true"></i><span>T</span>
                                                     </button>
                                                     <span class="analysis-control-set">
                                                         <span class="analysis-control-label">Pico</span>
@@ -966,11 +966,11 @@
                         tutorWatchActive = Boolean(active);
                         if (tutorWatchActive) {
                             tutorWatchBtn.classList.add('active');
-                            tutorWatchSpan.innerHTML = 'Tutor';
+                            tutorWatchSpan.innerHTML = 'T';
                             tutorWatchIcon.className = 'fa fa-eye';
                         } else {
                             tutorWatchBtn.classList.remove('active');
-                            tutorWatchSpan.innerHTML = 'Tutor';
+                            tutorWatchSpan.innerHTML = 'T';
                             tutorWatchIcon.className = 'fa fa-eye-slash';
                         }
                     }

--- a/web/picoweb/templates/clock.html
+++ b/web/picoweb/templates/clock.html
@@ -755,7 +755,7 @@
                                                     <div id="enginePvBody" class="pv-body"></div>
                                                 </div>
 
-                                                <hr class="my-1">
+                                                <hr class="my-1" id="analysisRowSeparator">
 
                                                 <!-- SF18 analysis (static header, JS updates content + extra PVs) -->
                                                 <div class="pv-two-row" id="sf18Row">


### PR DESCRIPTION
## Summary

This PR experiments with a more space-efficient ANALYSES tab for issue #412.

The main goal is to give users more room for the PGN move list and useful analysis output on small displays, especially:

- Raspberry Pi / WIMAXIT-style 7" 1024x600 landscape
- phone portrait views
- small portrait displays

## Changes

- Activates the intended `row-tabs` flex layout for the lower tab panel.
- Moves Pico/Web analysis controls into a compact toolbar.
- Collapses Pico and Web analysis rows completely when their buttons are set to `SHOW`.
- Lets the PGN move list consume freed space when analysis rows are hidden.
- Shortens the Web analysis heading to `Web`.
- Avoids repeating the Web heading on extra MultiPV rows (on remote web client like mobile phone).
- Keeps extra Web MultiPV rows compact: score + PV moves only.
- Shortens the Tutor toolbar button to icon + `T` for narrow portrait layouts of mobile phones into just one row.
- Tightens analysis toolbar spacing on phone-width screens.

## Tester Focus

Please test especially:

- 1024x600 landscape: PGN move list should get more useful space.
- Phone portrait: ANALYSES toolbar should avoid wrapping where possible.
- Pico `SHOW` / `HIDE`: row heading and analysis content should collapse/restore cleanly.
- Web `SHOW` / `HIDE`: row heading, score/depth/PV, and extra MultiPV rows should collapse/restore cleanly.
- Web plus/minus MultiPV controls should still work
- Dark theme labels should remain readable.

And of course: Test that touch display buttons are still big enough.