### PR TITLE
422 Add web PGN side-lines, decouple PGN loading from replay, and clarify active-game lifecycle - version 4.3.3

### DIFF
--- a/dgt/api.py
+++ b/dgt/api.py
@@ -58,6 +58,7 @@ class EventApi:
     SET_OPENING_BOOK = "EVT_SET_OPENING_BOOK"  # User chooses an opening book
     NEW_ENGINE = "EVT_NEW_ENGINE"  # Change engine
     SET_INTERACTION_MODE = "EVT_SET_INTERACTION_MODE"  # Change interaction mode
+    SET_PGN_REPLAY_TUTOR_REGENERATION = "EVT_SET_PGN_REPLAY_TUTOR_REGENERATION"
     SETUP_POSITION = "EVT_SETUP_POSITION"  # Setup custom position
     PAUSE_RESUME = "EVT_PAUSE_RESUME"  # Stops search or halt/resume running clock
     SWITCH_SIDES = "EVT_SWITCH_SIDES"  # Switch the side
@@ -342,6 +343,10 @@ class Event:
     SET_OPENING_BOOK = ClassFactory(EventApi.SET_OPENING_BOOK, ["book", "book_text", "show_ok"])
     NEW_ENGINE = ClassFactory(EventApi.NEW_ENGINE, ["eng", "eng_text", "options", "show_ok"])
     SET_INTERACTION_MODE = ClassFactory(EventApi.SET_INTERACTION_MODE, ["mode", "mode_text", "show_ok"])
+    SET_PGN_REPLAY_TUTOR_REGENERATION = ClassFactory(
+        EventApi.SET_PGN_REPLAY_TUTOR_REGENERATION,
+        ["enabled"],
+    )
     SETUP_POSITION = ClassFactory(EventApi.SETUP_POSITION, ["fen", "uci960", "game"])
     PAUSE_RESUME = ClassFactory(EventApi.PAUSE_RESUME, [])
     SWITCH_SIDES = ClassFactory(EventApi.SWITCH_SIDES, [])

--- a/dgt/api.py
+++ b/dgt/api.py
@@ -364,7 +364,7 @@ class Event:
     PICOCOMMENT = ClassFactory(EventApi.PICOCOMMENT, ["picocomment"])
     TAKE_BACK = ClassFactory(EventApi.TAKE_BACK, ["take_back"])
     RSPEED = ClassFactory(EventApi.RSPEED, ["rspeed"])
-    READ_GAME = ClassFactory(EventApi.READ_GAME, ["pgn_filename"])
+    READ_GAME = ClassFactory(EventApi.READ_GAME, ["pgn_filename", "show_headers"])
     SAVE_GAME = ClassFactory(EventApi.SAVE_GAME, ["pgn_filename"])
     CONTLAST = ClassFactory(EventApi.CONTLAST, ["contlast"])
     ALTMOVES = ClassFactory(EventApi.ALTMOVES, ["altmoves"])

--- a/dgt/menu.py
+++ b/dgt/menu.py
@@ -2544,27 +2544,27 @@ class DgtMenu(object):
             text = await self._fire_dispatchdgt(self.dgttranslate.text("B10_oksavegame"))
 
         elif self.state == MenuState.GAME_GAMEREAD_GAMELAST:
-            event = Event.READ_GAME(pgn_filename="last_game.pgn")
+            event = Event.READ_GAME(pgn_filename="last_game.pgn", show_headers=True)
             await Observable.fire(event)
             text = await self._fire_dispatchdgt(self.dgttranslate.text("B10_okreadgame"))
 
         elif self.state == MenuState.GAME_GAMEREAD_GAMEREPLAY:
-            event = Event.READ_GAME(pgn_filename="last_replay.pgn")
+            event = Event.READ_GAME(pgn_filename="last_replay.pgn", show_headers=True)
             await Observable.fire(event)
             text = await self._fire_dispatchdgt(self.dgttranslate.text("B10_okreadgame"))
 
         elif self.state == MenuState.GAME_GAMEREAD_GAME1:
-            event = Event.READ_GAME(pgn_filename="picochess_game_1.pgn")
+            event = Event.READ_GAME(pgn_filename="picochess_game_1.pgn", show_headers=True)
             await Observable.fire(event)
             text = await self._fire_dispatchdgt(self.dgttranslate.text("B10_okreadgame"))
 
         elif self.state == MenuState.GAME_GAMEREAD_GAME2:
-            event = Event.READ_GAME(pgn_filename="picochess_game_2.pgn")
+            event = Event.READ_GAME(pgn_filename="picochess_game_2.pgn", show_headers=True)
             await Observable.fire(event)
             text = await self._fire_dispatchdgt(self.dgttranslate.text("B10_okreadgame"))
 
         elif self.state == MenuState.GAME_GAMEREAD_GAME3:
-            event = Event.READ_GAME(pgn_filename="picochess_game_3.pgn")
+            event = Event.READ_GAME(pgn_filename="picochess_game_3.pgn", show_headers=True)
             await Observable.fire(event)
             text = await self._fire_dispatchdgt(self.dgttranslate.text("B10_okreadgame"))
 

--- a/dgt/menu.py
+++ b/dgt/menu.py
@@ -234,9 +234,10 @@ class MenuState(object):
     GAME_GAMESAVE_GAME3 = 913000
     GAME_GAMEREAD = 920000
     GAME_GAMEREAD_GAMELAST = 921000
-    GAME_GAMEREAD_GAME1 = 922000
-    GAME_GAMEREAD_GAME2 = 923000
-    GAME_GAMEREAD_GAME3 = 924000
+    GAME_GAMEREAD_GAMEREPLAY = 922000
+    GAME_GAMEREAD_GAME1 = 923000
+    GAME_GAMEREAD_GAME2 = 924000
+    GAME_GAMEREAD_GAME3 = 925000
     GAME_GAMEALTMOVE = 930000
     GAME_GAMEALTMOVE_ONOFF = 931000
     GAME_GAMECONTLAST = 940000
@@ -1190,6 +1191,12 @@ class DgtMenu(object):
         """Set the gameread state."""
         self.state = MenuState.GAME_GAMEREAD_GAMELAST
         text = self.dgttranslate.text("B00_game_read_gamelast")
+        return text
+
+    def enter_game_gameread_gamereplay_menu(self):
+        """Set the gameread state."""
+        self.state = MenuState.GAME_GAMEREAD_GAMEREPLAY
+        text = self.dgttranslate.text("B00_game_read_gamereplay")
         return text
 
     def enter_game_gameread_game1_menu(self):
@@ -2321,6 +2328,9 @@ class DgtMenu(object):
         elif self.state == MenuState.GAME_GAMEREAD_GAMELAST:
             text = self.enter_game_gameread_menu()
 
+        elif self.state == MenuState.GAME_GAMEREAD_GAMEREPLAY:
+            text = self.enter_game_gameread_menu()
+
         elif self.state == MenuState.GAME_GAMEREAD_GAME1:
             text = self.enter_game_gameread_menu()
 
@@ -2425,6 +2435,8 @@ class DgtMenu(object):
         elif self.state == MenuState.GAME_GAMEREAD:
             if self.menu_game_read == GameRead.GAMELAST:
                 text = self.enter_game_gameread_gamelast_menu()
+            if self.menu_game_read == GameRead.GAMEREPLAY:
+                text = self.enter_game_gameread_gamereplay_menu()
             if self.menu_game_read == GameRead.GAME1:
                 text = self.enter_game_gameread_game1_menu()
             if self.menu_game_read == GameRead.GAME2:
@@ -2500,6 +2512,11 @@ class DgtMenu(object):
 
         elif self.state == MenuState.GAME_GAMEREAD_GAMELAST:
             event = Event.READ_GAME(pgn_filename="last_game.pgn")
+            await Observable.fire(event)
+            text = await self._fire_dispatchdgt(self.dgttranslate.text("B10_okreadgame"))
+
+        elif self.state == MenuState.GAME_GAMEREAD_GAMEREPLAY:
+            event = Event.READ_GAME(pgn_filename="last_replay.pgn")
             await Observable.fire(event)
             text = await self._fire_dispatchdgt(self.dgttranslate.text("B10_okreadgame"))
 
@@ -3457,8 +3474,13 @@ class DgtMenu(object):
             self.menu_game_read = GameReadLoop.prev(self.menu_game_read)
             text = self.dgttranslate.text(self.menu_game_read.value)
 
-        elif self.state == MenuState.GAME_GAMEREAD_GAME1:
+        elif self.state == MenuState.GAME_GAMEREAD_GAMEREPLAY:
             self.state = MenuState.GAME_GAMEREAD_GAMELAST
+            self.menu_game_read = GameReadLoop.prev(self.menu_game_read)
+            text = self.dgttranslate.text(self.menu_game_read.value)
+
+        elif self.state == MenuState.GAME_GAMEREAD_GAME1:
+            self.state = MenuState.GAME_GAMEREAD_GAMEREPLAY
             self.menu_game_read = GameReadLoop.prev(self.menu_game_read)
             text = self.dgttranslate.text(self.menu_game_read.value)
 
@@ -4113,6 +4135,11 @@ class DgtMenu(object):
             text = self.dgttranslate.text(self.menu_game.value)
 
         elif self.state == MenuState.GAME_GAMEREAD_GAMELAST:
+            self.state = MenuState.GAME_GAMEREAD_GAMEREPLAY
+            self.menu_game_read = GameReadLoop.next(self.menu_game_read)
+            text = self.dgttranslate.text(self.menu_game_read.value)
+
+        elif self.state == MenuState.GAME_GAMEREAD_GAMEREPLAY:
             self.state = MenuState.GAME_GAMEREAD_GAME1
             self.menu_game_read = GameReadLoop.next(self.menu_game_read)
             text = self.dgttranslate.text(self.menu_game_read.value)

--- a/dgt/menu.py
+++ b/dgt/menu.py
@@ -97,6 +97,8 @@ class MenuState(object):
 
     MODE = 200000
     MODE_TYPE = 210000  # normal, observe, ...
+    MODE_PGNREPLAY_FAST = 211000
+    MODE_PGNREPLAY_TUTOR = 212000
 
     POS = 300000
     POS_COL = 310000
@@ -335,6 +337,7 @@ class DgtMenu(object):
             self.menu_top = Top.MODE
 
         self.menu_mode = Mode.NORMAL
+        self.menu_pgn_replay_tutor_regeneration = False
         self.engine_has_960 = False
         self.engine_has_ponder = False
         self.engine_restart = False
@@ -1020,6 +1023,18 @@ class DgtMenu(object):
         self.state = MenuState.MODE_TYPE
         text = self.dgttranslate.text(self.menu_mode.value)
         return text
+
+    def enter_mode_pgnreplay_fast_menu(self):
+        """Set the PGN replay option state."""
+        self.state = MenuState.MODE_PGNREPLAY_FAST
+        self.menu_pgn_replay_tutor_regeneration = False
+        return self.dgttranslate.text("B00_mode_pgnreplay_fast")
+
+    def enter_mode_pgnreplay_tutor_menu(self):
+        """Set the PGN replay option state."""
+        self.state = MenuState.MODE_PGNREPLAY_TUTOR
+        self.menu_pgn_replay_tutor_regeneration = True
+        return self.dgttranslate.text("B00_mode_pgnreplay_tutor")
 
     def enter_picotutor_menu(self):
         """Set the picotutor state."""
@@ -1962,6 +1977,12 @@ class DgtMenu(object):
         elif self.state == MenuState.MODE_TYPE:
             text = self.enter_mode_menu()
 
+        elif self.state == MenuState.MODE_PGNREPLAY_FAST:
+            text = self.enter_mode_type_menu()
+
+        elif self.state == MenuState.MODE_PGNREPLAY_TUTOR:
+            text = self.enter_mode_type_menu()
+
         elif self.state == MenuState.POS:
             text = self.enter_top_menu()
 
@@ -2395,10 +2416,22 @@ class DgtMenu(object):
             if self.menu_mode == Mode.BRAIN and not self.get_engine_has_ponder():
                 await DispatchDgt.fire(self.dgttranslate.text("Y10_erroreng"))
                 text = Dgt.DISPLAY_TIME(force=True, wait=True, devs={"ser", "i2c", "web"})
+            elif self.menu_mode == Mode.PGNREPLAY:
+                text = self.enter_mode_pgnreplay_fast_menu()
             else:
                 mode_text = self.dgttranslate.text("B10_okmode")
                 event = Event.SET_INTERACTION_MODE(mode=self.menu_mode, mode_text=mode_text, show_ok=True)
                 text = await self._fire_event(event)
+
+        elif self.state in (MenuState.MODE_PGNREPLAY_FAST, MenuState.MODE_PGNREPLAY_TUTOR):
+            await Observable.fire(
+                Event.SET_PGN_REPLAY_TUTOR_REGENERATION(
+                    enabled=self.menu_pgn_replay_tutor_regeneration
+                )
+            )
+            mode_text = self.dgttranslate.text("B10_okmode")
+            event = Event.SET_INTERACTION_MODE(mode=Mode.PGNREPLAY, mode_text=mode_text, show_ok=True)
+            text = await self._fire_event(event)
 
         elif self.state == MenuState.GAME:
             if self.menu_game == Game.NEW:
@@ -3609,6 +3642,12 @@ class DgtMenu(object):
             self.menu_mode = ModeLoop.prev(self.menu_mode)
             text = self.dgttranslate.text(self.menu_mode.value)
 
+        elif self.state == MenuState.MODE_PGNREPLAY_FAST:
+            text = self.enter_mode_pgnreplay_tutor_menu()
+
+        elif self.state == MenuState.MODE_PGNREPLAY_TUTOR:
+            text = self.enter_mode_pgnreplay_fast_menu()
+
         elif self.state == MenuState.POS:
             self.state = MenuState.MODE
             self.menu_top = TopLoop.prev(self.menu_top)
@@ -4288,6 +4327,12 @@ class DgtMenu(object):
         elif self.state == MenuState.MODE_TYPE:
             self.menu_mode = ModeLoop.next(self.menu_mode)
             text = self.dgttranslate.text(self.menu_mode.value)
+
+        elif self.state == MenuState.MODE_PGNREPLAY_FAST:
+            text = self.enter_mode_pgnreplay_tutor_menu()
+
+        elif self.state == MenuState.MODE_PGNREPLAY_TUTOR:
+            text = self.enter_mode_pgnreplay_fast_menu()
 
         elif self.state == MenuState.POS:
             self.state = MenuState.TIME

--- a/dgt/translate.py
+++ b/dgt/translate.py
@@ -4846,6 +4846,38 @@ class DgtTranslate(object):
                 medium_text="UltPart",
                 small_text="u.par",
             )
+        if text_id == "game_read_gamereplay":
+            entxt = Dgt.DISPLAY_TEXT(
+                web_text="",
+                large_text="last Replay",
+                medium_text="lastRepl",
+                small_text="replay",
+            )
+            ittxt = Dgt.DISPLAY_TEXT(
+                web_text="Carica l'ultimo replay",
+                large_text="Ult Replay",
+                medium_text="ultRepl",
+                small_text="replay",
+            )
+            detxt = Dgt.DISPLAY_TEXT(
+                web_text="",
+                large_text="letztRepla",
+                medium_text="letztRep",
+                small_text="replay",
+            )
+            nltxt = Dgt.DISPLAY_TEXT(
+                web_text="Laatste replay",
+                large_text="LaatsteRep",
+                medium_text="laatsRep",
+                small_text="replay",
+            )
+            frtxt = entxt
+            estxt = Dgt.DISPLAY_TEXT(
+                web_text="Cargar último replay",
+                large_text="Ult replay",
+                medium_text="UltRepl",
+                small_text="replay",
+            )
         if text_id == "game_read_game1":
             entxt = Dgt.DISPLAY_TEXT(
                 web_text="",

--- a/dgt/translate.py
+++ b/dgt/translate.py
@@ -5814,6 +5814,34 @@ class DgtTranslate(object):
                 medium_text="PGNRep ",
                 small_text="PGN  ",
             )
+        if text_id == "mode_pgnreplay_fast":
+            entxt = Dgt.DISPLAY_TEXT(
+                web_text="",
+                large_text="Replay    ",
+                medium_text="Replay ",
+                small_text="replay",
+            )
+            ittxt = detxt = nltxt = frtxt = entxt
+            estxt = Dgt.DISPLAY_TEXT(
+                web_text="Repetir PGN sin tutor",
+                large_text="Replay    ",
+                medium_text="Replay ",
+                small_text="replay",
+            )
+        if text_id == "mode_pgnreplay_tutor":
+            entxt = Dgt.DISPLAY_TEXT(
+                web_text="",
+                large_text="TutorLines",
+                medium_text="TutorLin",
+                small_text="tutlin",
+            )
+            ittxt = detxt = nltxt = frtxt = entxt
+            estxt = Dgt.DISPLAY_TEXT(
+                web_text="Repetir PGN con líneas tutor",
+                large_text="TutorLin",
+                medium_text="TutorLin",
+                small_text="tutlin",
+            )
         if text_id == "mode_analysis_menu":
             entxt = Dgt.DISPLAY_TEXT(
                 web_text="",

--- a/dgt/util.py
+++ b/dgt/util.py
@@ -184,13 +184,14 @@ class GameRead(MyEnum):
     """GameRead Class."""
 
     GAMELAST = "B00_game_read_gamelast"
+    GAMEREPLAY = "B00_game_read_gamereplay"
     GAME1 = "B00_game_read_game1"
     GAME2 = "B00_game_read_game2"
     GAME3 = "B00_game_read_game3"
 
     @classmethod
     def items(cls):
-        return [GameRead.GAMELAST, GameRead.GAME1, GameRead.GAME2, GameRead.GAME3]
+        return [GameRead.GAMELAST, GameRead.GAMEREPLAY, GameRead.GAME1, GameRead.GAME2, GameRead.GAME3]
 
 
 class GameReadLoop(object):

--- a/pgn.py
+++ b/pgn.py
@@ -74,6 +74,37 @@ def _picotutor_variation_first_move_exists(parent: chess.pgn.GameNode, move: che
     return any(variation.move == move for variation in parent.variations)
 
 
+def _copy_variation_subtree(target_parent: chess.pgn.GameNode, source_node: chess.pgn.GameNode) -> None:
+    """Copy a PGN subtree below target_parent."""
+    target_node = target_parent.add_variation(source_node.move)
+    target_node.comment = source_node.comment
+    target_node.starting_comment = source_node.starting_comment
+    target_node.nags.update(source_node.nags)
+    for source_child in source_node.variations:
+        _copy_variation_subtree(target_node, source_child)
+
+
+def preserve_loaded_pgn_variations(target_game: chess.pgn.Game, loaded_game: chess.pgn.Game | None) -> None:
+    """Copy existing loaded PGN side variations onto a regenerated mainline game."""
+    if not loaded_game:
+        return
+    target_parent: chess.pgn.GameNode = target_game
+    loaded_parent: chess.pgn.GameNode = loaded_game
+    while True:
+        for loaded_variation in loaded_parent.variations[1:]:
+            if not _picotutor_variation_first_move_exists(target_parent, loaded_variation.move):
+                _copy_variation_subtree(target_parent, loaded_variation)
+
+        if not loaded_parent.variations or not target_parent.variations:
+            return
+        loaded_mainline = loaded_parent.variations[0]
+        target_mainline = target_parent.variations[0]
+        if loaded_mainline.move != target_mainline.move:
+            return
+        loaded_parent = loaded_mainline
+        target_parent = target_mainline
+
+
 def add_picotutor_variations_to_node(node: chess.pgn.GameNode, value: dict):
     """Add stored tutor PVs as sibling variations before the evaluated node."""
     parent = node.parent
@@ -688,6 +719,7 @@ class PgnDisplay(DisplayMsg):
 
         # add picotutor stored evaluations before saving game
         self.add_picotutor_evaluation(pgn_game)
+        preserve_loaded_pgn_variations(pgn_game, self.shared.get("loaded_pgn_game"))
 
         # preserve headers, but exclude "Variant" so the value set by
         # _generate_pgn_from_message (or deliberately omitted for normal chess)
@@ -736,6 +768,7 @@ class PgnDisplay(DisplayMsg):
 
         # add picotutor stored evaluations before saving game
         self.add_picotutor_evaluation(pgn_game)
+        preserve_loaded_pgn_variations(pgn_game, self.shared.get("loaded_pgn_game"))
 
         # preserve headers, but exclude "Variant" so the value set by
         # _generate_pgn_from_message (or deliberately omitted for normal chess)

--- a/pgn.py
+++ b/pgn.py
@@ -535,7 +535,7 @@ class PgnDisplay(DisplayMsg):
 
         return pgn_game
 
-    def get_node_at_halfmove_nr(self, game: chess.Board, halfmove_nr: int) -> Optional[chess.pgn.GameNode]:
+    def get_node_at_halfmove_nr(self, game: chess.pgn.Game, halfmove_nr: int) -> Optional[chess.pgn.GameNode]:
         """get the node halfmove_nr (ply) in the game tree - 0 is like 1. e4"""
         nodes = list(game.mainline())
         if halfmove_nr - 1 < len(nodes):
@@ -543,7 +543,47 @@ class PgnDisplay(DisplayMsg):
         else:
             return None
 
-    def add_picotutor_evaluation(self, game: chess.Board):
+    def _parse_legal_variation_moves(self, parent: chess.pgn.GameNode, variation: dict) -> list[chess.Move]:
+        """Convert a stored tutor PV payload into legal moves from parent."""
+        if not isinstance(variation, dict):
+            return []
+        move_ucis = variation.get("moves", [])
+        if not isinstance(move_ucis, list):
+            return []
+        moves = []
+        board = parent.board()
+        for move_uci in move_ucis:
+            if not isinstance(move_uci, str):
+                return []
+            try:
+                move = chess.Move.from_uci(move_uci)
+            except ValueError:
+                return []
+            if move not in board.legal_moves:
+                return []
+            moves.append(move)
+            board.push(move)
+        return moves
+
+    def _variation_first_move_exists(self, parent: chess.pgn.GameNode, move: chess.Move) -> bool:
+        return any(variation.move == move for variation in parent.variations)
+
+    def _add_picotutor_variations(self, node: chess.pgn.GameNode, value: dict):
+        """Add stored tutor PVs as sibling variations before the evaluated node."""
+        parent = node.parent
+        if parent is None:
+            return
+        for variation in value.get("variations", []):
+            pv_moves = self._parse_legal_variation_moves(parent, variation)
+            if not pv_moves:
+                continue
+            if self._variation_first_move_exists(parent, pv_moves[0]):
+                continue
+            variation_node = parent.add_variation(pv_moves[0])
+            for move in pv_moves[1:]:
+                variation_node = variation_node.add_variation(move)
+
+    def add_picotutor_evaluation(self, game: chess.pgn.Game):
         """add picotutor evaluations to the game"""
         # see if we have an evaluation in picotutor
         if self.picotutor:
@@ -558,6 +598,7 @@ class PgnDisplay(DisplayMsg):
                         if nag != chess.pgn.NAG_NULL:
                             node.nags.add(nag)
                         node.comment = self._get_picotutor_eval_comments(nag, value, turn)
+                        self._add_picotutor_variations(node, value)
                     else:
                         logger.debug("skipped move %s-%s picotutor eval mismatch", pgn_move.uci(), user_move.uci())
 

--- a/pgn.py
+++ b/pgn.py
@@ -47,6 +47,68 @@ from picotutor import PicoTutor
 logger = logging.getLogger(__name__)
 
 
+def _parse_legal_picotutor_variation_moves(parent: chess.pgn.GameNode, variation: dict) -> list[chess.Move]:
+    """Convert a stored tutor PV payload into legal moves from parent."""
+    if not isinstance(variation, dict):
+        return []
+    move_ucis = variation.get("moves", [])
+    if not isinstance(move_ucis, list):
+        return []
+    moves = []
+    board = parent.board()
+    for move_uci in move_ucis:
+        if not isinstance(move_uci, str):
+            return []
+        try:
+            move = chess.Move.from_uci(move_uci)
+        except ValueError:
+            return []
+        if move not in board.legal_moves:
+            return []
+        moves.append(move)
+        board.push(move)
+    return moves
+
+
+def _picotutor_variation_first_move_exists(parent: chess.pgn.GameNode, move: chess.Move) -> bool:
+    return any(variation.move == move for variation in parent.variations)
+
+
+def add_picotutor_variations_to_node(node: chess.pgn.GameNode, value: dict):
+    """Add stored tutor PVs as sibling variations before the evaluated node."""
+    parent = node.parent
+    if parent is None:
+        return
+    for variation in value.get("variations", []):
+        pv_moves = _parse_legal_picotutor_variation_moves(parent, variation)
+        if not pv_moves:
+            continue
+        if _picotutor_variation_first_move_exists(parent, pv_moves[0]):
+            continue
+        variation_node = parent.add_variation(pv_moves[0])
+        for move in pv_moves[1:]:
+            variation_node = variation_node.add_variation(move)
+
+
+def add_picotutor_variations_to_game(game: chess.pgn.Game, picotutor: PicoTutor | None):
+    """Add stored tutor PV alternatives to a PGN game tree."""
+    if not picotutor:
+        return
+    eval_moves = picotutor.get_eval_moves()
+    nodes = list(game.mainline())
+    for (halfmove_nr, user_move, turn), value in eval_moves.items():
+        if halfmove_nr <= 0:
+            continue
+        if halfmove_nr - 1 >= len(nodes):
+            continue
+        node = nodes[halfmove_nr - 1]
+        pgn_move = node.move
+        if pgn_move == user_move and node.turn() == turn:
+            add_picotutor_variations_to_node(node, value)
+        else:
+            logger.debug("skipped move %s-%s picotutor variation mismatch", pgn_move.uci(), user_move.uci())
+
+
 # molli: support for player names from online game
 class ModeInfo:
     online_mode = False
@@ -543,46 +605,6 @@ class PgnDisplay(DisplayMsg):
         else:
             return None
 
-    def _parse_legal_variation_moves(self, parent: chess.pgn.GameNode, variation: dict) -> list[chess.Move]:
-        """Convert a stored tutor PV payload into legal moves from parent."""
-        if not isinstance(variation, dict):
-            return []
-        move_ucis = variation.get("moves", [])
-        if not isinstance(move_ucis, list):
-            return []
-        moves = []
-        board = parent.board()
-        for move_uci in move_ucis:
-            if not isinstance(move_uci, str):
-                return []
-            try:
-                move = chess.Move.from_uci(move_uci)
-            except ValueError:
-                return []
-            if move not in board.legal_moves:
-                return []
-            moves.append(move)
-            board.push(move)
-        return moves
-
-    def _variation_first_move_exists(self, parent: chess.pgn.GameNode, move: chess.Move) -> bool:
-        return any(variation.move == move for variation in parent.variations)
-
-    def _add_picotutor_variations(self, node: chess.pgn.GameNode, value: dict):
-        """Add stored tutor PVs as sibling variations before the evaluated node."""
-        parent = node.parent
-        if parent is None:
-            return
-        for variation in value.get("variations", []):
-            pv_moves = self._parse_legal_variation_moves(parent, variation)
-            if not pv_moves:
-                continue
-            if self._variation_first_move_exists(parent, pv_moves[0]):
-                continue
-            variation_node = parent.add_variation(pv_moves[0])
-            for move in pv_moves[1:]:
-                variation_node = variation_node.add_variation(move)
-
     def add_picotutor_evaluation(self, game: chess.pgn.Game):
         """add picotutor evaluations to the game"""
         # see if we have an evaluation in picotutor
@@ -598,7 +620,7 @@ class PgnDisplay(DisplayMsg):
                         if nag != chess.pgn.NAG_NULL:
                             node.nags.add(nag)
                         node.comment = self._get_picotutor_eval_comments(nag, value, turn)
-                        self._add_picotutor_variations(node, value)
+                        add_picotutor_variations_to_node(node, value)
                     else:
                         logger.debug("skipped move %s-%s picotutor eval mismatch", pgn_move.uci(), user_move.uci())
 

--- a/pgn.py
+++ b/pgn.py
@@ -109,6 +109,19 @@ def add_picotutor_variations_to_game(game: chess.pgn.Game, picotutor: PicoTutor 
             logger.debug("skipped move %s-%s picotutor variation mismatch", pgn_move.uci(), user_move.uci())
 
 
+def pgn_has_variations(game: chess.pgn.Game | None) -> bool:
+    """Return True if a PGN game contains any side variations."""
+    if not game:
+        return False
+    stack = [game]
+    while stack:
+        node = stack.pop()
+        if len(node.variations) > 1:
+            return True
+        stack.extend(node.variations)
+    return False
+
+
 # molli: support for player names from online game
 class ModeInfo:
     online_mode = False

--- a/pgn.py
+++ b/pgn.py
@@ -105,6 +105,20 @@ def preserve_loaded_pgn_variations(target_game: chess.pgn.Game, loaded_game: che
         target_parent = target_mainline
 
 
+def _is_definitive_pgn_result(result: object) -> bool:
+    return str(result or "").strip() in ("1-0", "0-1", "1/2-1/2")
+
+
+def preserve_loaded_pgn_result(target_game: chess.pgn.Game, loaded_game: chess.pgn.Game | None) -> None:
+    """Keep a loaded finished PGN result when regenerated save headers are non-final."""
+    if not loaded_game:
+        return
+    loaded_result = loaded_game.headers.get("Result") if loaded_game.headers else None
+    target_result = target_game.headers.get("Result") if target_game.headers else None
+    if _is_definitive_pgn_result(loaded_result) and not _is_definitive_pgn_result(target_result):
+        target_game.headers["Result"] = str(loaded_result).strip()
+
+
 def add_picotutor_variations_to_node(node: chess.pgn.GameNode, value: dict):
     """Add stored tutor PVs as sibling variations before the evaluated node."""
     parent = node.parent
@@ -726,6 +740,7 @@ class PgnDisplay(DisplayMsg):
         # is never overwritten by a stale entry in shared["headers"]
         shared_headers_without_variant = {k: v for k, v in self.shared["headers"].items() if k != "Variant"}
         pgn_game.headers.update(shared_headers_without_variant)
+        preserve_loaded_pgn_result(pgn_game, self.shared.get("loaded_pgn_game"))
         ensure_important_headers(pgn_game.headers)
 
         # In antichess, stalemate is a win for the stalemated side
@@ -775,6 +790,7 @@ class PgnDisplay(DisplayMsg):
         # is never overwritten by a stale entry in shared["headers"]
         shared_headers_without_variant = {k: v for k, v in self.shared["headers"].items() if k != "Variant"}
         pgn_game.headers.update(shared_headers_without_variant)
+        preserve_loaded_pgn_result(pgn_game, self.shared.get("loaded_pgn_game"))
         ensure_important_headers(pgn_game.headers)
 
         # In antichess, stalemate is a win for the stalemated side

--- a/pgn.py
+++ b/pgn.py
@@ -167,6 +167,45 @@ def pgn_has_variations(game: chess.pgn.Game | None) -> bool:
     return False
 
 
+def pgn_variation_review_points(game: chess.pgn.Game | None) -> list[dict]:
+    """Return lightweight WATCHER review points for mainline moves with sidelines."""
+    if not game:
+        return []
+
+    points: list[dict] = []
+    board = game.board()
+    parent: chess.pgn.GameNode = game
+    halfmove = 0
+
+    while parent.variations:
+        mainline_node = parent.variations[0]
+        halfmove += 1
+        move_prefix = f"{board.fullmove_number}." if board.turn == chess.WHITE else f"{board.fullmove_number}..."
+        try:
+            user_move = board.san(mainline_node.move)
+        except (AssertionError, ValueError):
+            user_move = mainline_node.move.uci()
+
+        if len(parent.variations) > 1:
+            points.append(
+                {
+                    "halfmove": halfmove,
+                    "target_halfmove": halfmove - 1 if halfmove > 2 else halfmove,
+                    "move_no": move_prefix,
+                    "user_move": user_move,
+                    "reason": "variation",
+                }
+            )
+
+        try:
+            board.push(mainline_node.move)
+        except (AssertionError, ValueError):
+            break
+        parent = mainline_node
+
+    return points
+
+
 # molli: support for player names from online game
 class ModeInfo:
     online_mode = False

--- a/pgn.py
+++ b/pgn.py
@@ -412,6 +412,7 @@ class PgnDisplay(DisplayMsg):
         self.engine_elo = "-"
         self.startime = datetime.datetime.now().strftime("%H:%M:%S")
         self.last_saved_game = None
+        self.last_saved_game_signature = None
         self.picotutor: PicoTutor | None = None
         self.shared = shared  # shared headers needed in generate_pgn_from_message
 
@@ -685,18 +686,6 @@ class PgnDisplay(DisplayMsg):
         pgn_game = self._pgn_game_from_message(message)
         pgn_game_last = pgn_game
 
-        # If we already saved the exact same game, do not
-        # save it again, and do not send an email
-        logger.debug(
-            "Comparing current game to last save game:\nCurrent Game: %s\nLast Saved Game: %s",
-            pgn_game,
-            self.last_saved_game,
-        )
-        if str(pgn_game) == str(self.last_saved_game):
-            logger.debug("Current game is the same as last saved gamed, skipping")
-            return
-        self.last_saved_game = pgn_game
-
         # add picotutor stored evaluations before saving game
         self.add_picotutor_evaluation(pgn_game)
 
@@ -714,6 +703,19 @@ class PgnDisplay(DisplayMsg):
                     pgn_game.headers["Result"] = "1-0"
                 else:
                     pgn_game.headers["Result"] = "0-1"
+
+        # Compare the final PGN payload, including comments and side variations.
+        save_signature = pgn_game.accept(chess.pgn.StringExporter(headers=True, comments=True, variations=True))
+        logger.debug(
+            "Comparing current save signature to last save signature:\nCurrent Game: %s\nLast Saved Game: %s",
+            pgn_game,
+            self.last_saved_game,
+        )
+        if save_signature == self.last_saved_game_signature:
+            logger.debug("Current game is the same as last saved game, skipping")
+            return
+        self.last_saved_game_signature = save_signature
+        self.last_saved_game = pgn_game
 
         # Save to last game file
         with open(self.last_file_name, "w") as last_file:

--- a/picochess.py
+++ b/picochess.py
@@ -76,7 +76,7 @@ from utilities import (
     set_window_control_backend_preference,
 )
 from utilities import AsyncRepeatingTimer
-from pgn import Emailer, PgnDisplay, ModeInfo
+from pgn import Emailer, PgnDisplay, ModeInfo, pgn_has_variations
 from server import WebDisplay, WebServer, WebVr, EventHandler
 from picotalker import PicoTalkerDisplay
 from dispatcher import Dispatcher
@@ -316,6 +316,10 @@ class PicochessState:
         self.pgn_replay_next_move_fen = ""
         self.pgn_replay_next_move = None
         self.pgn_replay_book_cache = {}
+        self.loaded_pgn_has_variations = False
+        self.pgn_replay_tutor_regeneration = True
+        self.loaded_pgn_game: Game | None = None
+        self.loaded_pgn_filename = ""
         self.picotutor: PicoTutor | None = None
         self.last_hand_coach_move: chess.Move | None = None
         self.hand_coach_task: asyncio.Task | None = None
@@ -3239,8 +3243,12 @@ async def main() -> None:
                     l_mate = ""
                     t_hint_move = chess.Move.null()
                     valid = await self.state.picotutor.push_move(move, self.state.game)
+                    regenerate_pgn_replay_tutor = (
+                        self.state.interaction_mode != Mode.PGNREPLAY
+                        or self.state.pgn_replay_tutor_regeneration
+                    )
                     # get evalutaion result and give user feedback
-                    if self.state.dgtmenu.get_picowatcher():
+                    if self.state.dgtmenu.get_picowatcher() and regenerate_pgn_replay_tutor:
                         if valid:
                             eval_str, l_mate = self.state.picotutor.get_user_move_eval()
                         else:
@@ -3590,6 +3598,15 @@ async def main() -> None:
             result = result and not (self.eng_plays() and not self.state.is_user_turn() and engine_thinking)
             return result
 
+        def tutor_analysis_enabled_for_current_mode(self) -> bool:
+            """Return whether tutor analysis should run for the current mode."""
+            if not tutor_analysis_allowed_in_mode(self.state.interaction_mode):
+                return False
+            return not (
+                self.state.interaction_mode == Mode.PGNREPLAY
+                and not self.state.pgn_replay_tutor_regeneration
+            )
+
         def eng_plays(self) -> bool:
             """return true if engine is playing moves"""
             return bool(self.state.interaction_mode in (Mode.NORMAL, Mode.BRAIN, Mode.TRAINING))
@@ -3739,10 +3756,14 @@ async def main() -> None:
             # @todo give it a separate timer task when this is stable
             if allow_autoplay and self.state.autoplay_pgn_file and self.can_do_next_pgn_replay_move():
                 next_move = self._get_cached_pgn_next_move()
+                wait_for_replay_tutor = (
+                    self.state.pgn_replay_tutor_regeneration
+                    and self.state.picotutor.can_use_coach_analyser()
+                )
                 if self._pgn_next_move_in_book(next_move):
                     await asyncio.sleep(1.0)
                     await self.autoplay_pgnreplay_move(allow_game_ends=True, next_move=next_move)  # book move
-                elif self.state.picotutor.can_use_coach_analyser():
+                elif wait_for_replay_tutor:
                     if analysed_fen == self.state.get_fen():
                         latest_depth = await self.state.picotutor.get_latest_seen_depth()
                         min_depth = max(DEEP_DEPTH - 2, 1)
@@ -4133,22 +4154,44 @@ async def main() -> None:
             self.state.newgame_happened = False
             self.state.last_error_fen = external_fen
 
-        async def read_pgn_file(self, file_name: str):
+        async def read_pgn_file(
+            self,
+            file_name: str,
+            start_replay: bool = False,
+            pgn_game: Game | None = None,
+        ):
             """Read game from PGN file"""
             logger.debug("molli: read game from pgn file")
 
             l_filename = "games" + os.sep + file_name
-            try:
-                l_file_pgn = open(l_filename)
-                if not l_file_pgn:
+            if pgn_game is None:
+                try:
+                    l_file_pgn = open(l_filename)
+                    if not l_file_pgn:
+                        return
+                except OSError:
                     return
-            except OSError:
-                return
 
-            l_game_pgn: Game | None = chess.pgn.read_game(l_file_pgn)
-            l_file_pgn.close()
+                l_game_pgn: Game | None = chess.pgn.read_game(l_file_pgn)
+                l_file_pgn.close()
+            else:
+                l_game_pgn = pgn_game
+                l_filename = file_name
 
             logger.debug("molli: read game filename %s", l_filename)
+            if l_game_pgn is None:
+                logger.warning("No PGN game found in %s", l_filename)
+                return
+            loaded_pgn_has_variations = pgn_has_variations(l_game_pgn)
+            self.state.loaded_pgn_has_variations = loaded_pgn_has_variations
+            self.state.pgn_replay_tutor_regeneration = not loaded_pgn_has_variations
+            self.shared.setdefault("system_info", {})
+            self.shared["system_info"].update(
+                {
+                    "loaded_pgn_has_variations": loaded_pgn_has_variations,
+                    "pgn_replay_tutor_regeneration": self.state.pgn_replay_tutor_regeneration,
+                }
+            )
 
             await self.stop_search_and_clock()
             # reset best depth so new analysis results are not filtered by previous game
@@ -4194,6 +4237,7 @@ async def main() -> None:
 
             result_header_raw = l_game_pgn.headers.get("Result") if l_game_pgn.headers else None
             result_header = str(result_header_raw).strip() if result_header_raw else ""
+            loaded_game_finished = bool(result_header and result_header not in ("*", "?"))
             if result_header_raw:
                 display_result = result_header or str(result_header_raw)
                 await DisplayMsg.show(Message.SHOW_TEXT(text_string=display_result))
@@ -4202,6 +4246,8 @@ async def main() -> None:
             # make sure we have "?" in important missing headers to
             # prevent overwrite by existing user or engine names or elos etc
             ensure_important_headers(l_game_pgn.headers)
+            self.state.loaded_pgn_game = copy.deepcopy(l_game_pgn)
+            self.state.loaded_pgn_filename = file_name
 
             await DisplayMsg.show(Message.READ_GAME)
 
@@ -4216,7 +4262,7 @@ async def main() -> None:
             except ValueError:
                 l_stop_at_halfmove = None
 
-            if not l_stop_at_halfmove:
+            if start_replay and not l_stop_at_halfmove:
                 # no PicoStop override found above - check game result
                 if result_header and result_header not in ("*", "?"):
                     # a game with a final result was loaded - issue #54
@@ -4240,7 +4286,7 @@ async def main() -> None:
             # @ todo Pico V3 made user + engine move here = unnecessary waiting for engine move
             # Pico V4 only makes an engine move... just to update the web screen and main states?
             # maybe there is a smarter way to do this?
-            if not fen_header and l_move and l_stop_at_halfmove != 0:
+            if start_replay and not fen_header and l_move and l_stop_at_halfmove != 0:
                 self.state.pop_move()
                 self._update_variant_shared()
 
@@ -4254,12 +4300,14 @@ async def main() -> None:
             old_flag_picotutor = self.state.flag_picotutor
             self.state.flag_picotutor = False
             old_interaction_mode = self.state.interaction_mode
-            self.state.interaction_mode = Mode.PGNREPLAY  # new mode for loaded PGN games
+            if start_replay:
+                self.state.interaction_mode = Mode.PGNREPLAY
             self._set_pgn_replay_autoplay(False)  # if you load a 2nd PGN it will autosave from move 1
-            self.state.dgtmenu.set_mode(Mode.PGNREPLAY)
-            self.state.dgtmenu.exit_menu()  # leave menu so that PAUSE_RESUME avoids "no function"
+            if start_replay:
+                self.state.dgtmenu.set_mode(Mode.PGNREPLAY)
+                self.state.dgtmenu.exit_menu()  # leave menu so that PAUSE_RESUME avoids "no function"
 
-            if l_move and l_stop_at_halfmove != 0:
+            if start_replay and l_move and l_stop_at_halfmove != 0:
                 # publish current position to webserver
                 await self.user_move(l_move, sliding=True)
 
@@ -4269,6 +4317,9 @@ async def main() -> None:
                 self.state.dgtmenu.set_mode(Mode.KIBITZ)
             elif fen_header:
                 logger.warning("FEN header found but could not apply board setup: %s", fen_header)
+            elif start_replay:
+                # else remain in PGNREPLAY mode
+                pass
             elif not result_header or result_header in ("*", "?"):
                 # issue #54 game is not finished - switch back to playing mode
                 if old_interaction_mode in (Mode.NORMAL, Mode.BRAIN, Mode.TRAINING):
@@ -4277,7 +4328,12 @@ async def main() -> None:
                 else:
                     self.state.interaction_mode = Mode.NORMAL
                 self.state.dgtmenu.set_mode(self.state.interaction_mode)
-            # else remain in PGNREPLAY mode
+            elif old_interaction_mode in (Mode.NORMAL, Mode.BRAIN, Mode.TRAINING):
+                self.state.interaction_mode = old_interaction_mode
+                self.state.dgtmenu.set_mode(self.state.interaction_mode)
+            else:
+                self.state.interaction_mode = Mode.NORMAL
+                self.state.dgtmenu.set_mode(Mode.NORMAL)
 
             # restore picotutor flag to previous state
             self.state.flag_picotutor = old_flag_picotutor
@@ -4285,6 +4341,7 @@ async def main() -> None:
             await self.engine.stop_analysis()  # stop possible engine analyser
             if self.eng_plays():
                 await self.state.picotutor.stop()  # stop possible old tutor analysers
+            await self.state.picotutor.set_analysis_enabled(self.tutor_analysis_enabled_for_current_mode())
             await self.state.picotutor.set_mode(self.pgn_mode() or not self.eng_plays())
 
             await self.stop_search_and_clock()
@@ -4362,11 +4419,50 @@ async def main() -> None:
             self.state.last_legal_fens = []
             await self.stop_search_and_clock()
 
+            game_end = self.state.check_game_state()
+            if not start_replay and not fen_header:
+                self._set_game_started(not loaded_game_finished and not game_end)
+            system_info_update = {
+                "game_started": self.state.game_started,
+                "interaction_mode": self.state.interaction_mode.name.lower(),
+                "loaded_pgn_has_variations": loaded_pgn_has_variations,
+                "pgn_replay_tutor_regeneration": self.state.pgn_replay_tutor_regeneration,
+                "pgn_replay_autoplay": self.state.autoplay_pgn_file,
+            }
+            self.shared.setdefault("system_info", {})
+            self.shared["system_info"].update(system_info_update)
+            EventHandler.write_to_clients({"event": "SystemInfo", "msg": system_info_update})
+            logger.info(
+                "loaded PGN %s: mode=%s game_started=%s variations=%s tutor_regeneration=%s",
+                l_filename,
+                self.state.interaction_mode.name.lower(),
+                self.state.game_started,
+                loaded_pgn_has_variations,
+                self.state.pgn_replay_tutor_regeneration,
+            )
+
             self.shared["headers"] = l_game_pgn.headers  # update headers from file
             EventHandler.write_to_clients({"event": "Header", "headers": dict(self.shared["headers"])})
             await asyncio.sleep(0.1)  # give time to write_to_clients
+            if not start_replay:
+                pgn_str = l_game_pgn.accept(
+                    chess.pgn.StringExporter(headers=True, comments=True, variations=True)
+                )
+                try:
+                    mov = self.state.game.peek().uci()
+                except IndexError:
+                    mov = chess.Move.null().uci()
+                result = {
+                    "pgn": pgn_str,
+                    "fen": self.state.get_fen(),
+                    "event": "Fen",
+                    "move": mov,
+                    "play": "reload",
+                    "variant": self.shared.get("variant", "chess"),
+                }
+                self.shared["last_dgt_move_msg"] = result
+                EventHandler.write_to_clients(result)
 
-            game_end = self.state.check_game_state()
             if game_end:
                 self.state.play_mode = PlayMode.USER_WHITE if turn == chess.WHITE else PlayMode.USER_BLACK
                 self.state.legal_fens = []
@@ -4386,7 +4482,7 @@ async def main() -> None:
                     await asyncio.sleep(1)
 
             self.state.take_back_locked = True  # important otherwise problems for setting up the position
-            if not fen_header:
+            if start_replay and not fen_header:
                 pgn_game_to_step = None if l_stop_at_halfmove is None else l_game_pgn
                 if pgn_game_to_step:
                     # this PGN game was not loaded to the end (above) - remember it
@@ -4498,11 +4594,10 @@ async def main() -> None:
 
         async def engine_mode(self):
             """call when engine mode is changed"""
+            tutor_analysis_enabled = self.tutor_analysis_enabled_for_current_mode()
             if self.state.picotutor is not None:
-                await self.state.picotutor.set_analysis_enabled(
-                    tutor_analysis_allowed_in_mode(self.state.interaction_mode)
-                )
-            if not tutor_analysis_allowed_in_mode(self.state.interaction_mode):
+                await self.state.picotutor.set_analysis_enabled(tutor_analysis_enabled)
+            if not tutor_analysis_enabled:
                 await DisplayMsg.show(Message.WEB_ANALYSIS(analysis={"source": "tutor", "clear": True}))
             if self.state.interaction_mode in (Mode.NORMAL, Mode.BRAIN, Mode.TRAINING):
                 # optimisation, dont ask for ponder unless needed
@@ -4595,7 +4690,7 @@ async def main() -> None:
             """check if we can do the next pgn move"""
             if self.state.interaction_mode != Mode.PGNREPLAY or self.state.game.is_game_over():
                 return False
-            if self.state.picotutor.get_pgn_game_to_step is None:
+            if self.state.picotutor.get_pgn_game_to_step() is None:
                 return False  # No game to try to step through
             if self.board_type == dgt.util.EBoard.NOEBOARD:
                 # on web display we can always autoplay the next pgn move
@@ -5231,6 +5326,8 @@ async def main() -> None:
                 await self.get_rid_of_engine_move()
                 self._set_game_started(False)
                 self._set_pgn_replay_autoplay(False)  # stop auto replay of pgn file if new game started
+                self.state.loaded_pgn_game = None
+                self.state.loaded_pgn_filename = ""
                 last_move_no = self.state.game.fullmove_number
                 self.state.takeback_active = False
                 self.state.automatic_takeback = False
@@ -6387,9 +6484,19 @@ async def main() -> None:
                         self.state.newgame_happened = False
                     await self.stop_search_and_clock()
                     if event.mode == Mode.PGNREPLAY:
-                        file_name_only = "last_game.pgn"
-                        await DisplayMsg.show(Message.READ_GAME(pgn_filename=file_name_only))
-                        await self.read_pgn_file(file_name_only)
+                        loaded_pgn_game = self.state.loaded_pgn_game
+                        if loaded_pgn_game is not None:
+                            file_name_only = self.state.loaded_pgn_filename or "loaded PGN"
+                            await DisplayMsg.show(Message.READ_GAME(pgn_filename=file_name_only))
+                            await self.read_pgn_file(
+                                file_name_only,
+                                start_replay=True,
+                                pgn_game=copy.deepcopy(loaded_pgn_game),
+                            )
+                        else:
+                            file_name_only = "last_game.pgn"
+                            await DisplayMsg.show(Message.READ_GAME(pgn_filename=file_name_only))
+                            await self.read_pgn_file(file_name_only, start_replay=True)
                         await self._start_or_stop_analysis_as_needed()
                     else:
                         self.state.interaction_mode = event.mode

--- a/picochess.py
+++ b/picochess.py
@@ -170,7 +170,7 @@ def remote_move_matches_current_position(move: chess.Move, posted_fen: str | Non
     if not posted_fen:
         return True
     if move not in board.legal_moves:
-        return True
+        return False
     try:
         expected = board.copy(stack=False)
         expected.push(move)

--- a/picochess.py
+++ b/picochess.py
@@ -3688,6 +3688,15 @@ async def main() -> None:
             self.shared["system_info"].update(update)
             EventHandler.write_to_clients({"event": "SystemInfo", "msg": update})
 
+        def _reset_loaded_pgn_lifecycle(self) -> None:
+            """Clear PGN/replay state when starting a fresh playable game."""
+            self.state.loaded_pgn_game = None
+            self.state.loaded_pgn_filename = ""
+            self.state.loaded_pgn_has_variations = False
+            self.state.loaded_pgn_finished = False
+            self.state.pgn_replay_tutor_regeneration = True
+            self.state.pgn_replay_tutor_regeneration_override = None
+
         async def get_rid_of_engine_move(self):
             """in some mode switches we need to get rid of a move engine is thinking about"""
             if self.eng_plays() and self.engine.is_thinking():
@@ -5334,6 +5343,10 @@ async def main() -> None:
                                 mode=self.state.interaction_mode,
                             )
                         )
+                self._set_game_started(False)
+                self._set_pgn_replay_autoplay(False)
+                self._reset_loaded_pgn_lifecycle()
+                ModeInfo.set_game_ending(result="*")
                 event_game = getattr(event, "game", None)
                 if event_game is not None:
                     self.state.game = event_game.copy(stack=True)
@@ -5396,12 +5409,7 @@ async def main() -> None:
                 await self.get_rid_of_engine_move()
                 self._set_game_started(False)
                 self._set_pgn_replay_autoplay(False)  # stop auto replay of pgn file if new game started
-                self.state.loaded_pgn_game = None
-                self.state.loaded_pgn_filename = ""
-                self.state.loaded_pgn_has_variations = False
-                self.state.loaded_pgn_finished = False
-                self.state.pgn_replay_tutor_regeneration = True
-                self.state.pgn_replay_tutor_regeneration_override = None
+                self._reset_loaded_pgn_lifecycle()
                 last_move_no = self.state.game.fullmove_number
                 self.state.takeback_active = False
                 self.state.automatic_takeback = False

--- a/picochess.py
+++ b/picochess.py
@@ -4176,11 +4176,13 @@ async def main() -> None:
             file_name: str,
             start_replay: bool = False,
             pgn_game: Game | None = None,
+            show_headers: bool = True,
         ):
             """Read game from PGN file"""
             logger.debug("molli: read game from pgn file")
 
             using_loaded_pgn_object = pgn_game is not None
+            show_pgn_headers = show_headers and not using_loaded_pgn_object
             l_filename = "games" + os.sep + file_name
             if pgn_game is None:
                 try:
@@ -4246,11 +4248,11 @@ async def main() -> None:
                 if (event_str or "").startswith("PicoChess"):
                     is_pico_save_game = True  # game was saved by Pico
                 logger.debug(f"is_pico_save_game: {is_pico_save_game}")  # TODO clarify usage of is_pico_save_game
-                if not using_loaded_pgn_object:
+                if show_pgn_headers:
                     await DisplayMsg.show(Message.SHOW_TEXT(text_string=str(event_str)))
                     await asyncio.sleep(update_speed)
 
-            if not using_loaded_pgn_object:
+            if show_pgn_headers:
                 if l_game_pgn.headers["White"]:
                     await DisplayMsg.show(Message.SHOW_TEXT(text_string=str(l_game_pgn.headers["White"])))
                     await asyncio.sleep(update_speed)
@@ -4266,7 +4268,7 @@ async def main() -> None:
             result_header = str(result_header_raw).strip() if result_header_raw else ""
             loaded_game_finished = bool(result_header and result_header not in ("*", "?"))
             self.state.loaded_pgn_finished = loaded_game_finished
-            if result_header_raw and not using_loaded_pgn_object:
+            if result_header_raw and show_pgn_headers:
                 display_result = result_header or str(result_header_raw)
                 await DisplayMsg.show(Message.SHOW_TEXT(text_string=display_result))
                 await asyncio.sleep(update_speed)
@@ -4277,7 +4279,7 @@ async def main() -> None:
             self.state.loaded_pgn_game = copy.deepcopy(l_game_pgn)
             self.state.loaded_pgn_filename = file_name
 
-            if not using_loaded_pgn_object:
+            if show_pgn_headers:
                 await DisplayMsg.show(Message.READ_GAME)
 
             # check if we should stop loading pgn game "in the middle"
@@ -6578,8 +6580,10 @@ async def main() -> None:
 
             elif isinstance(event, Event.READ_GAME):
                 if event.pgn_filename:
-                    await DisplayMsg.show(Message.READ_GAME(pgn_filename=event.pgn_filename))
-                    await self.read_pgn_file(event.pgn_filename)
+                    show_headers = getattr(event, "show_headers", True)
+                    if show_headers:
+                        await DisplayMsg.show(Message.READ_GAME(pgn_filename=event.pgn_filename))
+                    await self.read_pgn_file(event.pgn_filename, show_headers=show_headers)
                     await self._start_or_stop_analysis_as_needed()
 
             elif isinstance(event, Event.CONTLAST):

--- a/picochess.py
+++ b/picochess.py
@@ -165,6 +165,21 @@ def should_reject_user_move_after_game_end(
     return bool(game_declared) or (game_ending or "*") != "*"
 
 
+def remote_move_matches_current_position(move: chess.Move, posted_fen: str | None, board: chess.Board) -> bool:
+    """Return true when a web move's posted resulting FEN matches the live board."""
+    if not posted_fen:
+        return True
+    if move not in board.legal_moves:
+        return True
+    try:
+        expected = board.copy(stack=False)
+        expected.push(move)
+        posted_board_fen = posted_fen.split()[0]
+    except (IndexError, ValueError, AssertionError):
+        return False
+    return posted_board_fen == expected.board_fen()
+
+
 class AlternativeMover:
     """Keep track of alternative moves."""
 
@@ -5982,6 +5997,18 @@ async def main() -> None:
                 if event.move.from_square == event.move.to_square:
                     await self._handle_same_square_input(event.move.from_square)
                 elif self.board_type == dgt.util.EBoard.NOEBOARD:
+                    if not remote_move_matches_current_position(
+                        event.move,
+                        getattr(event, "fen", ""),
+                        self.state.get_move_check_board(),
+                    ):
+                        logger.info(
+                            "ignoring stale web move [%s] for fen %s; live fen is %s",
+                            event.move,
+                            getattr(event, "fen", ""),
+                            self.state.game.fen(),
+                        )
+                        return
                     # Mirror process_fen(): once a real user move starts the new
                     # game, the next BEST_MOVE belongs to this game, not the
                     # previous-game stale-move guard.
@@ -5989,6 +6016,18 @@ async def main() -> None:
                     await self.user_move(event.move, sliding=False)
                 else:
                     if self.state.interaction_mode == Mode.REMOTE and self.state.is_not_user_turn():
+                        if not remote_move_matches_current_position(
+                            event.move,
+                            getattr(event, "fen", ""),
+                            self.state.get_move_check_board(),
+                        ):
+                            logger.info(
+                                "ignoring stale remote web move [%s] for fen %s; live fen is %s",
+                                event.move,
+                                getattr(event, "fen", ""),
+                                self.state.game.fen(),
+                            )
+                            return
                         await self.stop_search_and_clock()
                         await DisplayMsg.show(
                             Message.COMPUTER_MOVE(

--- a/picochess.py
+++ b/picochess.py
@@ -165,6 +165,15 @@ def should_reject_user_move_after_game_end(
     return bool(game_declared) or (game_ending or "*") != "*"
 
 
+def should_stop_analysis_after_game_end(
+    interaction_mode: Mode, game_over: bool, game_declared: bool, game_ending: str | None
+) -> bool:
+    """Return true when playing-mode deep analysis should stop after game end."""
+    if interaction_mode not in (Mode.NORMAL, Mode.BRAIN, Mode.TRAINING):
+        return False
+    return bool(game_over) or bool(game_declared) or (game_ending or "*") != "*"
+
+
 def remote_move_matches_current_position(move: chess.Move, posted_fen: str | None, board: chess.Board) -> bool:
     """Return true when a web move's posted resulting FEN matches the live board."""
     if not posted_fen:
@@ -3613,6 +3622,8 @@ async def main() -> None:
             """return true if engine is analysing moves based on PlayMode"""
             if self.pgn_mode() or (self.engine and self.engine.should_skip_engine_analyser()):
                 return False
+            if self.playing_game_analysis_stopped():
+                return False
             if self.eng_plays() and self.state.loaded_pgn_finished:
                 return False
             # Save CPU at idle startup: skip analyser on the untouched standard
@@ -3643,6 +3654,8 @@ async def main() -> None:
             """Return whether tutor analysis should run for the current mode."""
             if not tutor_analysis_allowed_in_mode(self.state.interaction_mode):
                 return False
+            if self.playing_game_analysis_stopped():
+                return False
             if self.eng_plays() and self.state.loaded_pgn_finished:
                 return False
             return not (
@@ -3653,6 +3666,15 @@ async def main() -> None:
         def eng_plays(self) -> bool:
             """return true if engine is playing moves"""
             return bool(self.state.interaction_mode in (Mode.NORMAL, Mode.BRAIN, Mode.TRAINING))
+
+        def playing_game_analysis_stopped(self) -> bool:
+            """Return true when a completed playing-mode game must not analyse."""
+            return should_stop_analysis_after_game_end(
+                self.state.interaction_mode,
+                self.state.game.is_game_over(),
+                self.state.game_declared,
+                ModeInfo.get_game_ending(),
+            )
 
         def _set_game_started(self, started: bool) -> None:
             """Update active-game lifecycle state and publish it to web clients."""
@@ -3739,6 +3761,11 @@ async def main() -> None:
             analysed_fen = ""  # analysis is only valid for this fen
             analysed_fen_for_web_engine = ""
             analysed_fen_for_web_tutor = ""
+            if self.playing_game_analysis_stopped():
+                await self._start_or_stop_analysis_as_needed()
+                if self.state.picotutor is not None:
+                    await self.state.picotutor.set_analysis_enabled(False)
+                return None
             if self.is_coach_analyser() and self.state.picotutor.can_use_coach_analyser():
                 # here picotutor engine replaces playing engine analysis to save cpu
                 result = await self.state.picotutor.get_analysis()
@@ -5381,6 +5408,8 @@ async def main() -> None:
                 self.state.time_control.reset()
                 self.state.searchmoves.reset()
                 self.state.game_declared = False
+                if self.state.picotutor is not None:
+                    await self.state.picotutor.set_analysis_enabled(self.tutor_analysis_enabled_for_current_mode())
 
                 await self.set_picotutor_position(new_game=True)
                 await self.set_wait_state(self.state.new_game_msg(newgame=True))
@@ -5517,6 +5546,8 @@ async def main() -> None:
                     self.state.best_move_posted = False
                     self.state.searchmoves.reset()
                     self.state.game_declared = False
+                    if self.state.picotutor is not None:
+                        await self.state.picotutor.set_analysis_enabled(self.tutor_analysis_enabled_for_current_mode())
                     await self.update_elo_display()
 
                     if self.online_mode():
@@ -5640,6 +5671,8 @@ async def main() -> None:
                         self.state.legal_fens_after_cmove = []
                         self.is_out_of_time_already = False
                         self.state.game_declared = False
+                        if self.state.picotutor is not None:
+                            await self.state.picotutor.set_analysis_enabled(self.tutor_analysis_enabled_for_current_mode())
                         await self.set_wait_state(
                             self.state.new_game_msg(newgame=newgame),
                         )

--- a/picochess.py
+++ b/picochess.py
@@ -156,6 +156,15 @@ def should_show_setpieces_after_lift_timeout(lifted_piece_char: str, is_hand_mod
     return lifted_piece_char in ("K", "k") or not is_hand_mode
 
 
+def should_reject_user_move_after_game_end(
+    interaction_mode: Mode, game_declared: bool, game_ending: str | None
+) -> bool:
+    """Return true when a playing-mode move should not alter an ended game."""
+    if interaction_mode not in (Mode.NORMAL, Mode.BRAIN, Mode.TRAINING, Mode.REMOTE):
+        return False
+    return bool(game_declared) or (game_ending or "*") != "*"
+
+
 class AlternativeMover:
     """Keep track of alternative moves."""
 
@@ -3108,6 +3117,19 @@ async def main() -> None:
             self.state.take_back_locked = False
 
             logger.info("user move [%s] sliding: %s", move, sliding)
+            game_ending = ModeInfo.get_game_ending()
+            if should_reject_user_move_after_game_end(
+                self.state.interaction_mode, self.state.game_declared, game_ending
+            ):
+                logger.info(
+                    "ignoring user move [%s] after game end: mode=%s declared=%s result=%s",
+                    move,
+                    self.state.interaction_mode,
+                    self.state.game_declared,
+                    game_ending,
+                )
+                return False
+
             # Use variant board for legality check (atomic has different legal moves after explosions)
             move_check_board = self.state.get_move_check_board()
             if move not in move_check_board.legal_moves:

--- a/picochess.py
+++ b/picochess.py
@@ -76,7 +76,7 @@ from utilities import (
     set_window_control_backend_preference,
 )
 from utilities import AsyncRepeatingTimer
-from pgn import Emailer, PgnDisplay, ModeInfo, pgn_has_variations
+from pgn import Emailer, PgnDisplay, ModeInfo, pgn_has_variations, pgn_variation_review_points
 from server import WebDisplay, WebServer, WebVr, EventHandler
 from picotalker import PicoTalkerDisplay
 from dispatcher import Dispatcher
@@ -4567,6 +4567,7 @@ async def main() -> None:
                     "move": mov,
                     "play": "reload",
                     "variant": self.shared.get("variant", "chess"),
+                    "mistakes": pgn_variation_review_points(l_game_pgn),
                 }
                 self.shared["last_dgt_move_msg"] = result
                 EventHandler.write_to_clients(result)

--- a/picochess.py
+++ b/picochess.py
@@ -319,6 +319,7 @@ class PicochessState:
         self.loaded_pgn_has_variations = False
         self.loaded_pgn_finished = False
         self.pgn_replay_tutor_regeneration = True
+        self.pgn_replay_tutor_regeneration_override: bool | None = None
         self.loaded_pgn_game: Game | None = None
         self.loaded_pgn_filename = ""
         self.picotutor: PicoTutor | None = None
@@ -3639,6 +3640,17 @@ async def main() -> None:
             self.shared["system_info"].update(update)
             EventHandler.write_to_clients({"event": "SystemInfo", "msg": update})
 
+        def _set_pgn_replay_tutor_regeneration(self, enabled: bool, override: bool = False) -> None:
+            """Update PGN replay tutor regeneration and publish it to web clients."""
+            enabled = bool(enabled)
+            self.state.pgn_replay_tutor_regeneration = enabled
+            if override:
+                self.state.pgn_replay_tutor_regeneration_override = enabled
+            self.shared.setdefault("system_info", {})
+            update = {"pgn_replay_tutor_regeneration": enabled}
+            self.shared["system_info"].update(update)
+            EventHandler.write_to_clients({"event": "SystemInfo", "msg": update})
+
         async def get_rid_of_engine_move(self):
             """in some mode switches we need to get rid of a move engine is thinking about"""
             if self.eng_plays() and self.engine.is_thinking():
@@ -4189,7 +4201,14 @@ async def main() -> None:
                 return
             loaded_pgn_has_variations = pgn_has_variations(l_game_pgn)
             self.state.loaded_pgn_has_variations = loaded_pgn_has_variations
-            self.state.pgn_replay_tutor_regeneration = not loaded_pgn_has_variations
+            replay_regeneration_override = self.state.pgn_replay_tutor_regeneration_override
+            if start_replay and replay_regeneration_override is not None:
+                self.state.pgn_replay_tutor_regeneration = replay_regeneration_override
+                self.state.pgn_replay_tutor_regeneration_override = None
+            else:
+                self.state.pgn_replay_tutor_regeneration = not loaded_pgn_has_variations
+                if not start_replay:
+                    self.state.pgn_replay_tutor_regeneration_override = None
             self.shared.setdefault("system_info", {})
             self.shared["system_info"].update(
                 {
@@ -5339,6 +5358,7 @@ async def main() -> None:
                 self.state.loaded_pgn_has_variations = False
                 self.state.loaded_pgn_finished = False
                 self.state.pgn_replay_tutor_regeneration = True
+                self.state.pgn_replay_tutor_regeneration_override = None
                 last_move_no = self.state.game.fullmove_number
                 self.state.takeback_active = False
                 self.state.automatic_takeback = False
@@ -6498,7 +6518,6 @@ async def main() -> None:
                         loaded_pgn_game = self.state.loaded_pgn_game
                         if loaded_pgn_game is not None:
                             file_name_only = self.state.loaded_pgn_filename or "loaded PGN"
-                            await DisplayMsg.show(Message.READ_GAME(pgn_filename=file_name_only))
                             await self.read_pgn_file(
                                 file_name_only,
                                 start_replay=True,
@@ -6506,7 +6525,6 @@ async def main() -> None:
                             )
                         else:
                             file_name_only = "last_game.pgn"
-                            await DisplayMsg.show(Message.READ_GAME(pgn_filename=file_name_only))
                             await self.read_pgn_file(file_name_only, start_replay=True)
                         await self._start_or_stop_analysis_as_needed()
                     else:
@@ -6516,6 +6534,13 @@ async def main() -> None:
                             mode=event.mode, mode_text=event.mode_text, show_ok=event.show_ok
                         )
                         await self.set_wait_state(msg)  # dont clear searchmoves here
+
+            elif isinstance(event, Event.SET_PGN_REPLAY_TUTOR_REGENERATION):
+                self._set_pgn_replay_tutor_regeneration(event.enabled, override=True)
+                if self.state.picotutor is not None:
+                    await self.state.picotutor.set_analysis_enabled(self.tutor_analysis_enabled_for_current_mode())
+                    await self.state.picotutor.set_mode(self.pgn_mode() or not self.eng_plays())
+                await self._start_or_stop_analysis_as_needed()
 
             elif isinstance(event, Event.SET_OPENING_BOOK):
                 book_file = event.book["file"]

--- a/picochess.py
+++ b/picochess.py
@@ -5996,6 +5996,18 @@ async def main() -> None:
                 self.state.flag_startup = False
                 if event.move.from_square == event.move.to_square:
                     await self._handle_same_square_input(event.move.from_square)
+                elif should_reject_user_move_after_game_end(
+                    self.state.interaction_mode,
+                    self.state.game_declared,
+                    ModeInfo.get_game_ending(),
+                ):
+                    logger.info(
+                        "ignoring remote move [%s] after game end: mode=%s declared=%s result=%s",
+                        event.move,
+                        self.state.interaction_mode,
+                        self.state.game_declared,
+                        ModeInfo.get_game_ending(),
+                    )
                 elif self.board_type == dgt.util.EBoard.NOEBOARD:
                     if not remote_move_matches_current_position(
                         event.move,

--- a/picochess.py
+++ b/picochess.py
@@ -7028,24 +7028,14 @@ async def main() -> None:
                 else:
                     logger.debug("ignore clock time - too low prio: %s", event.dev)
             elif isinstance(event, Event.OUT_OF_TIME):
-                # molli: allow further playing even when run out of time
+                # Local timeout is a soft warning: Picochess historically allows
+                # casual play to continue after the clock flag falls.
                 if (
                     not self.is_out_of_time_already and not self.online_mode()
                 ):  # molli in online mode the server decides
                     await self.state.stop_clock()
-                    result = GameResult.OUT_OF_TIME
-                    self.game_end_event()
-                    await DisplayMsg.show(
-                        Message.GAME_ENDS(
-                            tc_init=self.state.time_control.get_parameters(),
-                            result=result,
-                            play_mode=self.state.play_mode,
-                            game=self.state.game.copy(),
-                            mode=self.state.interaction_mode,
-                        )
-                    )
+                    await DisplayMsg.show(Message.LOST_ON_TIME())
                     self.is_out_of_time_already = True
-                    await self.update_elo(result)
 
             elif isinstance(event, Event.SHUTDOWN):
                 await self.get_rid_of_engine_move()

--- a/picochess.py
+++ b/picochess.py
@@ -4180,6 +4180,7 @@ async def main() -> None:
             """Read game from PGN file"""
             logger.debug("molli: read game from pgn file")
 
+            using_loaded_pgn_object = pgn_game is not None
             l_filename = "games" + os.sep + file_name
             if pgn_game is None:
                 try:
@@ -4245,25 +4246,27 @@ async def main() -> None:
                 if (event_str or "").startswith("PicoChess"):
                     is_pico_save_game = True  # game was saved by Pico
                 logger.debug(f"is_pico_save_game: {is_pico_save_game}")  # TODO clarify usage of is_pico_save_game
-                await DisplayMsg.show(Message.SHOW_TEXT(text_string=str(event_str)))
+                if not using_loaded_pgn_object:
+                    await DisplayMsg.show(Message.SHOW_TEXT(text_string=str(event_str)))
+                    await asyncio.sleep(update_speed)
+
+            if not using_loaded_pgn_object:
+                if l_game_pgn.headers["White"]:
+                    await DisplayMsg.show(Message.SHOW_TEXT(text_string=str(l_game_pgn.headers["White"])))
+                    await asyncio.sleep(update_speed)
+
+                await DisplayMsg.show(Message.SHOW_TEXT(text_string="versus"))
                 await asyncio.sleep(update_speed)
 
-            if l_game_pgn.headers["White"]:
-                await DisplayMsg.show(Message.SHOW_TEXT(text_string=str(l_game_pgn.headers["White"])))
-                await asyncio.sleep(update_speed)
-
-            await DisplayMsg.show(Message.SHOW_TEXT(text_string="versus"))
-            await asyncio.sleep(update_speed)
-
-            if l_game_pgn.headers["Black"]:
-                await DisplayMsg.show(Message.SHOW_TEXT(text_string=str(l_game_pgn.headers["Black"])))
-                await asyncio.sleep(update_speed)
+                if l_game_pgn.headers["Black"]:
+                    await DisplayMsg.show(Message.SHOW_TEXT(text_string=str(l_game_pgn.headers["Black"])))
+                    await asyncio.sleep(update_speed)
 
             result_header_raw = l_game_pgn.headers.get("Result") if l_game_pgn.headers else None
             result_header = str(result_header_raw).strip() if result_header_raw else ""
             loaded_game_finished = bool(result_header and result_header not in ("*", "?"))
             self.state.loaded_pgn_finished = loaded_game_finished
-            if result_header_raw:
+            if result_header_raw and not using_loaded_pgn_object:
                 display_result = result_header or str(result_header_raw)
                 await DisplayMsg.show(Message.SHOW_TEXT(text_string=display_result))
                 await asyncio.sleep(update_speed)
@@ -4274,7 +4277,8 @@ async def main() -> None:
             self.state.loaded_pgn_game = copy.deepcopy(l_game_pgn)
             self.state.loaded_pgn_filename = file_name
 
-            await DisplayMsg.show(Message.READ_GAME)
+            if not using_loaded_pgn_object:
+                await DisplayMsg.show(Message.READ_GAME)
 
             # check if we should stop loading pgn game "in the middle"
             # this feature can be used to "jump to" a certain position in pgn

--- a/picochess.py
+++ b/picochess.py
@@ -3696,6 +3696,7 @@ async def main() -> None:
             self.state.loaded_pgn_finished = False
             self.state.pgn_replay_tutor_regeneration = True
             self.state.pgn_replay_tutor_regeneration_override = None
+            self.shared.pop("loaded_pgn_game", None)
 
         async def get_rid_of_engine_move(self):
             """in some mode switches we need to get rid of a move engine is thinking about"""
@@ -4324,6 +4325,7 @@ async def main() -> None:
             ensure_important_headers(l_game_pgn.headers)
             self.state.loaded_pgn_game = copy.deepcopy(l_game_pgn)
             self.state.loaded_pgn_filename = file_name
+            self.shared["loaded_pgn_game"] = copy.deepcopy(l_game_pgn)
 
             if show_pgn_headers:
                 await DisplayMsg.show(Message.READ_GAME)

--- a/picochess.py
+++ b/picochess.py
@@ -317,6 +317,7 @@ class PicochessState:
         self.pgn_replay_next_move = None
         self.pgn_replay_book_cache = {}
         self.loaded_pgn_has_variations = False
+        self.loaded_pgn_finished = False
         self.pgn_replay_tutor_regeneration = True
         self.loaded_pgn_game: Game | None = None
         self.loaded_pgn_filename = ""
@@ -3574,6 +3575,8 @@ async def main() -> None:
             """return true if engine is analysing moves based on PlayMode"""
             if self.pgn_mode() or (self.engine and self.engine.should_skip_engine_analyser()):
                 return False
+            if self.eng_plays() and self.state.loaded_pgn_finished:
+                return False
             # Save CPU at idle startup: skip analyser on the untouched standard
             # starting position until the game lifecycle has actually begun.
             if (
@@ -3601,6 +3604,8 @@ async def main() -> None:
         def tutor_analysis_enabled_for_current_mode(self) -> bool:
             """Return whether tutor analysis should run for the current mode."""
             if not tutor_analysis_allowed_in_mode(self.state.interaction_mode):
+                return False
+            if self.eng_plays() and self.state.loaded_pgn_finished:
                 return False
             return not (
                 self.state.interaction_mode == Mode.PGNREPLAY
@@ -4238,6 +4243,7 @@ async def main() -> None:
             result_header_raw = l_game_pgn.headers.get("Result") if l_game_pgn.headers else None
             result_header = str(result_header_raw).strip() if result_header_raw else ""
             loaded_game_finished = bool(result_header and result_header not in ("*", "?"))
+            self.state.loaded_pgn_finished = loaded_game_finished
             if result_header_raw:
                 display_result = result_header or str(result_header_raw)
                 await DisplayMsg.show(Message.SHOW_TEXT(text_string=display_result))
@@ -4426,6 +4432,7 @@ async def main() -> None:
                 "game_started": self.state.game_started,
                 "interaction_mode": self.state.interaction_mode.name.lower(),
                 "loaded_pgn_has_variations": loaded_pgn_has_variations,
+                "loaded_pgn_finished": loaded_game_finished,
                 "pgn_replay_tutor_regeneration": self.state.pgn_replay_tutor_regeneration,
                 "pgn_replay_autoplay": self.state.autoplay_pgn_file,
             }
@@ -4433,10 +4440,11 @@ async def main() -> None:
             self.shared["system_info"].update(system_info_update)
             EventHandler.write_to_clients({"event": "SystemInfo", "msg": system_info_update})
             logger.info(
-                "loaded PGN %s: mode=%s game_started=%s variations=%s tutor_regeneration=%s",
+                "loaded PGN %s: mode=%s game_started=%s finished=%s variations=%s tutor_regeneration=%s",
                 l_filename,
                 self.state.interaction_mode.name.lower(),
                 self.state.game_started,
+                loaded_game_finished,
                 loaded_pgn_has_variations,
                 self.state.pgn_replay_tutor_regeneration,
             )
@@ -5328,6 +5336,9 @@ async def main() -> None:
                 self._set_pgn_replay_autoplay(False)  # stop auto replay of pgn file if new game started
                 self.state.loaded_pgn_game = None
                 self.state.loaded_pgn_filename = ""
+                self.state.loaded_pgn_has_variations = False
+                self.state.loaded_pgn_finished = False
+                self.state.pgn_replay_tutor_regeneration = True
                 last_move_no = self.state.game.fullmove_number
                 self.state.takeback_active = False
                 self.state.automatic_takeback = False

--- a/picochess.py
+++ b/picochess.py
@@ -82,7 +82,16 @@ from picotalker import PicoTalkerDisplay
 from dispatcher import Dispatcher
 
 from dgt.api import Message, Event
-from dgt.util import GameResult, TimeMode, Mode, PlayMode, PicoComment, PicoCoach, game_result_from_header
+from dgt.util import (
+    GameResult,
+    TimeMode,
+    Mode,
+    PlayMode,
+    PicoComment,
+    PicoCoach,
+    flip_board_fen,
+    game_result_from_header,
+)
 from dgt.hw import DgtHw
 from dgt.pi import DgtPi
 from dgt.display import DgtDisplay
@@ -2582,6 +2591,26 @@ async def main() -> None:
             # wrong moves.
             _move_board = self.state.get_move_check_board()
             legal_fens_pico = compute_legal_fens(self.state.game.copy(), self.state.get_variant_board())
+            if (
+                self.board_type == dgt.util.EBoard.DGT
+                and not self.state.dgtmenu.get_flip_board()
+                and fen
+            ):
+                flipped_fen = flip_board_fen(fen)
+                known_fens = set(legal_fens_pico)
+                known_fens.update(self.state.legal_fens)
+                known_fens.update(self.state.last_legal_fens)
+                known_fens.update(self.state.legal_fens_after_cmove)
+                known_fens.add(self.state.get_board_fen())
+                if self.state.done_computer_fen:
+                    known_fens.add(self.state.done_computer_fen)
+                if flipped_fen != fen and flipped_fen in known_fens and fen not in known_fens:
+                    logger.info(
+                        "DGT board orientation inferred from position; switching to B-in-front orientation"
+                    )
+                    self.state.dgtmenu.set_position_reverse_flipboard(True, self.state.play_mode)
+                    self.state.dgtmenu.set_dgt_fen(flipped_fen)
+                    fen = flipped_fen
             starting_board_fen = (
                 RK_STARTING_BOARD_FEN if self.state.variant == "racingkings" else chess.STARTING_BOARD_FEN
             )

--- a/picotutor.py
+++ b/picotutor.py
@@ -807,6 +807,35 @@ class PicoTutor:
                 return t
         return None
 
+    def _get_better_pv_variations(self, turn: chess.Color, user_move: chess.Move, limit: int = 3) -> list[dict]:
+        """Return tutor PVs ranked ahead of user_move as compact PGN variation data."""
+        variations = []
+        best_moves = self.best_moves.get(turn, [])
+        selected_index = None
+        for index, (_pv_key, move, _score, _mate) in enumerate(best_moves):
+            if move == user_move:
+                selected_index = index
+                break
+
+        candidate_moves = best_moves[:selected_index] if selected_index is not None else best_moves
+        for pv_key, move, score, mate in candidate_moves:
+            if len(variations) >= limit:
+                break
+            if move == user_move or move == chess.Move.null() or pv_key is None:
+                continue
+            try:
+                info = self.best_info[turn][pv_key]
+            except (IndexError, KeyError, TypeError):
+                continue
+            pv = info.get("pv") if info else None
+            if not pv:
+                continue
+            pv_moves = [pv_move.uci() for pv_move in pv if pv_move != chess.Move.null()]
+            if not pv_moves:
+                continue
+            variations.append({"moves": pv_moves, "score": score, "mate": mate})
+        return variations
+
     def sort_score(self, tupel):
         """define score:int as sort key"""
         return tupel[2]
@@ -1104,6 +1133,9 @@ class PicoTutor:
             logger.debug("best move: %s, user move: %s", e_value["best_move"], e_value["user_move"])
         except (KeyError, ValueError, AttributeError):
             logger.warning("picotutor failed to convert to san for %s", current_move)
+        variations = self._get_better_pv_variations(self.board.turn, current_move)
+        if variations:
+            e_value["variations"] = variations
         if e_value["nag"] == chess.pgn.NAG_NULL:
             # no NAG to store, due to takeback make sure this e_key eval is empty
             self.evaluated_moves.pop(e_key, None)  # None prevents KeyError

--- a/server.py
+++ b/server.py
@@ -879,11 +879,16 @@ class ChannelHandler(ServerRequestHandler):
         elif action == "load_game":
             try:
                 slot = int(self.get_argument("slot", "1"))
-                if slot not in (0, 1, 2, 3):
+                if slot not in (0, 1, 2, 3, 4):
                     slot = 1
             except (ValueError, TypeError):
                 slot = 1
-            pgn_fn = "last_game.pgn" if slot == 0 else f"picochess_game_{slot}.pgn"
+            if slot == 0:
+                pgn_fn = "last_game.pgn"
+            elif slot == 4:
+                pgn_fn = "last_replay.pgn"
+            else:
+                pgn_fn = f"picochess_game_{slot}.pgn"
             await Observable.fire(Event.READ_GAME(pgn_filename=pgn_fn))
         elif action == "game_end":
             _result_map = {

--- a/server.py
+++ b/server.py
@@ -2611,6 +2611,15 @@ class WebDisplay(DisplayMsg):
         self.shared["system_info"]["pending_engine_move"] = pending
         EventHandler.write_to_clients({"event": "SystemInfo", "msg": {"pending_engine_move": pending}})
 
+    def _set_game_started(self, started: bool, force: bool = False):
+        """Publish the active-game lifecycle state used by the web client."""
+        self._create_system_info()
+        started = bool(started)
+        if not force and self.shared["system_info"].get("game_started") == started:
+            return
+        self.shared["system_info"]["game_started"] = started
+        EventHandler.write_to_clients({"event": "SystemInfo", "msg": {"game_started": started}})
+
     def _create_headers(self):
         if "headers" not in self.shared:
             self.shared["headers"] = OrderedDict()
@@ -3372,6 +3381,7 @@ class WebDisplay(DisplayMsg):
                     EventHandler.write_to_clients({"event": "BrainHint", "squares": []})
 
         elif isinstance(message, Message.GAME_ENDS):
+            self._set_game_started(False, force=True)
             if message.result == GameResult.DRAW:
                 WebDisplay.result_sav = "1/2-1/2"
             elif message.result in (GameResult.WIN_WHITE, GameResult.WIN_BLACK):

--- a/server.py
+++ b/server.py
@@ -73,7 +73,7 @@ from dgt.util import EBoard as EBoardType
 from timecontrol import TimeControl
 from dgt.iface import DgtIface
 from eboard.eboard import EBoard as EBoardProtocol
-from pgn import ModeInfo
+from pgn import ModeInfo, add_picotutor_variations_to_game
 
 # This needs to be reworked to be session based (probably by token)
 # Otherwise multiple clients behind a NAT can all play as the 'player'
@@ -2866,7 +2866,8 @@ class WebDisplay(DisplayMsg):
                 pgn_game = pgn.Game().from_board(game)
             self._build_game_header(pgn_game, keep_these_headers)
             self.shared["headers"] = pgn_game.headers
-            return pgn_game.accept(pgn.StringExporter(headers=True, comments=False, variations=False))
+            add_picotutor_variations_to_game(pgn_game, self.shared.get("picotutor"))
+            return pgn_game.accept(pgn.StringExporter(headers=True, comments=False, variations=True))
 
         def peek_uci(game: chess.Board):
             """Return last move in uci format."""

--- a/server.py
+++ b/server.py
@@ -861,6 +861,7 @@ class ChannelHandler(ServerRequestHandler):
                 self.write({"error": "Could not set position"})
                 return
         elif action == "pgn_replay":
+            await Observable.fire(Event.SET_PGN_REPLAY_TUTOR_REGENERATION(enabled=False))
             await Observable.fire(
                 Event.SET_INTERACTION_MODE(
                     mode=Mode.PGNREPLAY,
@@ -1082,6 +1083,9 @@ class ChannelHandler(ServerRequestHandler):
             }
             mode_name = self.get_argument("mode", "normal").lower()
             mode_val, _ = _mode_map.get(mode_name, (Mode.NORMAL, "Normal"))
+            if mode_val == Mode.PGNREPLAY:
+                tutor_lines = self.get_argument("tutor_lines", "false").lower() in ("1", "true", "yes", "on")
+                await Observable.fire(Event.SET_PGN_REPLAY_TUTOR_REGENERATION(enabled=tutor_lines))
             await Observable.fire(
                 Event.SET_INTERACTION_MODE(
                     mode=mode_val,

--- a/server.py
+++ b/server.py
@@ -890,7 +890,7 @@ class ChannelHandler(ServerRequestHandler):
                 pgn_fn = "last_replay.pgn"
             else:
                 pgn_fn = f"picochess_game_{slot}.pgn"
-            await Observable.fire(Event.READ_GAME(pgn_filename=pgn_fn))
+            await Observable.fire(Event.READ_GAME(pgn_filename=pgn_fn, show_headers=False))
         elif action == "game_end":
             _result_map = {
                 "white": GameResult.WIN_WHITE,

--- a/server.py
+++ b/server.py
@@ -1442,6 +1442,8 @@ class DGTHandler(ServerRequestHandler):
                     except Exception as exc:  # pragma: no cover - defensive for UI
                         logger.debug("failed to collect tutor mistakes: %s", exc)
                 self.write(result)
+            else:
+                self.write({})
 
 
 class InfoHandler(ServerRequestHandler):

--- a/tests/test_pgn.py
+++ b/tests/test_pgn.py
@@ -5,7 +5,7 @@ import datetime
 import unittest
 
 from dgt.util import PlayMode
-from pgn import PgnDisplay
+from pgn import PgnDisplay, add_picotutor_variations_to_game
 
 EMPTY_GAME = """[Event "PicoChess Game"]
 [Site "?"]
@@ -132,3 +132,23 @@ class TestPgnDisplay(unittest.TestCase):
         self.testee.add_picotutor_evaluation(game)
 
         self.assertEqual([variation.move.uci() for variation in game.variations], ["e2e4"])
+
+    def test_add_picotutor_variations_to_game_exports_without_comments(self):
+        board = chess.Board()
+        user_move = chess.Move.from_uci("e2e4")
+        board.push(user_move)
+        game = chess.pgn.Game.from_board(board)
+        add_picotutor_variations_to_game(
+            game,
+            FakePicoTutor(
+                {
+                    (1, user_move, chess.BLACK): {
+                        "variations": [{"moves": ["g1f3", "d7d5"], "score": 1000, "mate": 0}],
+                    }
+                }
+            ),
+        )
+
+        pgn_text = game.accept(chess.pgn.StringExporter(headers=False, comments=False, variations=True))
+
+        self.assertEqual(pgn_text, "1. e4 ( 1. Nf3 d5 ) *")

--- a/tests/test_pgn.py
+++ b/tests/test_pgn.py
@@ -195,7 +195,9 @@ class TestPgnDisplay(unittest.TestCase):
         self.assertEqual(pgn_text, "1. e4 ( 1. Nf3 d5 ) 1... e5 *")
 
     def test_save_pgn_preserves_loaded_side_lines(self):
-        loaded_game = chess.pgn.read_game(io.StringIO("1. e4 ( 1. Nf3 d5 ) e5 *"))
+        loaded_game = chess.pgn.read_game(
+            io.StringIO('[Result "0-1"]\n\n1. e4 ( 1. Nf3 d5 ) e5 0-1')
+        )
         board = chess.Board()
         board.push(chess.Move.from_uci("e2e4"))
         board.push(chess.Move.from_uci("e7e5"))
@@ -208,7 +210,7 @@ class TestPgnDisplay(unittest.TestCase):
             testee = PgnDisplay(
                 tmpdir + "/games.pgn",
                 FakeEmailer(),
-                {"headers": {}, "variant": "chess", "loaded_pgn_game": loaded_game},
+                {"headers": {"Result": "*"}, "variant": "chess", "loaded_pgn_game": loaded_game},
                 self.loop,
             )
             testee._save_pgn(msg)
@@ -217,6 +219,8 @@ class TestPgnDisplay(unittest.TestCase):
                 saved_text = saved_file.read()
 
         self.assertIn("( 1. Nf3 d5 )", saved_text)
+        self.assertIn('[Result "0-1"]', saved_text)
+        self.assertTrue(saved_text.rstrip().endswith("0-1"))
 
     def test_game_end_duplicate_check_uses_final_pgn_with_variations(self):
         user_move = chess.Move.from_uci("e2e4")

--- a/tests/test_pgn.py
+++ b/tests/test_pgn.py
@@ -2,11 +2,13 @@ import asyncio
 
 import chess  # type: ignore[import]
 import datetime
+import io
+import os
 import tempfile
 import unittest
 
 from dgt.util import PlayMode
-from pgn import PgnDisplay, add_picotutor_variations_to_game, pgn_has_variations
+from pgn import PgnDisplay, add_picotutor_variations_to_game, pgn_has_variations, preserve_loaded_pgn_variations
 
 EMPTY_GAME = """[Event "PicoChess Game"]
 [Site "?"]
@@ -179,6 +181,42 @@ class TestPgnDisplay(unittest.TestCase):
         board.push(chess.Move.from_uci("e2e4"))
         board.push(chess.Move.from_uci("e7e5"))
         self.assertFalse(pgn_has_variations(chess.pgn.Game.from_board(board)))
+
+    def test_preserve_loaded_pgn_variations_copies_matching_loaded_side_lines(self):
+        loaded_game = chess.pgn.read_game(io.StringIO("1. e4 ( 1. Nf3 d5 ) e5 *"))
+        board = chess.Board()
+        board.push(chess.Move.from_uci("e2e4"))
+        board.push(chess.Move.from_uci("e7e5"))
+        target_game = chess.pgn.Game.from_board(board)
+
+        preserve_loaded_pgn_variations(target_game, loaded_game)
+
+        pgn_text = target_game.accept(chess.pgn.StringExporter(headers=False, comments=False, variations=True))
+        self.assertEqual(pgn_text, "1. e4 ( 1. Nf3 d5 ) 1... e5 *")
+
+    def test_save_pgn_preserves_loaded_side_lines(self):
+        loaded_game = chess.pgn.read_game(io.StringIO("1. e4 ( 1. Nf3 d5 ) e5 *"))
+        board = chess.Board()
+        board.push(chess.Move.from_uci("e2e4"))
+        board.push(chess.Move.from_uci("e7e5"))
+        msg = FakeMessage(board, PlayMode.USER_WHITE)
+        msg.mode = None
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            saved_path = os.path.join(tmpdir, "saved.pgn")
+            msg.pgn_filename = os.path.relpath(saved_path, "games")
+            testee = PgnDisplay(
+                tmpdir + "/games.pgn",
+                FakeEmailer(),
+                {"headers": {}, "variant": "chess", "loaded_pgn_game": loaded_game},
+                self.loop,
+            )
+            testee._save_pgn(msg)
+
+            with open(saved_path, "r") as saved_file:
+                saved_text = saved_file.read()
+
+        self.assertIn("( 1. Nf3 d5 )", saved_text)
 
     def test_game_end_duplicate_check_uses_final_pgn_with_variations(self):
         user_move = chess.Move.from_uci("e2e4")

--- a/tests/test_pgn.py
+++ b/tests/test_pgn.py
@@ -5,7 +5,7 @@ import datetime
 import unittest
 
 from dgt.util import PlayMode
-from pgn import PgnDisplay, add_picotutor_variations_to_game
+from pgn import PgnDisplay, add_picotutor_variations_to_game, pgn_has_variations
 
 EMPTY_GAME = """[Event "PicoChess Game"]
 [Site "?"]
@@ -152,3 +152,21 @@ class TestPgnDisplay(unittest.TestCase):
         pgn_text = game.accept(chess.pgn.StringExporter(headers=False, comments=False, variations=True))
 
         self.assertEqual(pgn_text, "1. e4 ( 1. Nf3 d5 ) *")
+
+    def test_pgn_has_variations_detects_root_and_nested_side_lines(self):
+        root_variation_game = chess.pgn.Game()
+        root_variation_game.add_variation(chess.Move.from_uci("e2e4"))
+        root_variation_game.add_variation(chess.Move.from_uci("g1f3"))
+        self.assertTrue(pgn_has_variations(root_variation_game))
+
+        nested_variation_game = chess.pgn.Game()
+        mainline = nested_variation_game.add_variation(chess.Move.from_uci("e2e4"))
+        mainline.add_variation(chess.Move.from_uci("e7e5"))
+        mainline.add_variation(chess.Move.from_uci("c7c5"))
+        self.assertTrue(pgn_has_variations(nested_variation_game))
+
+    def test_pgn_has_variations_ignores_plain_mainline(self):
+        board = chess.Board()
+        board.push(chess.Move.from_uci("e2e4"))
+        board.push(chess.Move.from_uci("e7e5"))
+        self.assertFalse(pgn_has_variations(chess.pgn.Game.from_board(board)))

--- a/tests/test_pgn.py
+++ b/tests/test_pgn.py
@@ -31,6 +31,14 @@ class FakeMessage:
         self.tc_init = {"internal_time": {chess.WHITE: 0, chess.BLACK: 0}}
 
 
+class FakePicoTutor:
+    def __init__(self, eval_moves):
+        self.eval_moves = eval_moves
+
+    def get_eval_moves(self):
+        return self.eval_moves
+
+
 class TestPgnDisplay(unittest.TestCase):
     def setUp(self):
         self.loop = asyncio.new_event_loop()
@@ -45,3 +53,82 @@ class TestPgnDisplay(unittest.TestCase):
         empty_game = EMPTY_GAME.format(datetime.date.today().strftime("%Y.%m.%d"), self.testee.startime)
 
         self.assertEqual(str(pgn), empty_game)
+
+    def test_add_picotutor_evaluation_adds_better_pv_as_sibling_variation(self):
+        board = chess.Board()
+        user_move = chess.Move.from_uci("e2e4")
+        board.push(user_move)
+        game = chess.pgn.Game.from_board(board)
+        self.testee.set_picotutor(
+            FakePicoTutor(
+                {
+                    (1, user_move, chess.BLACK): {
+                        "nag": chess.pgn.NAG_MISTAKE,
+                        "best_move": "Nf3",
+                        "user_move": "e4",
+                        "CPL": 1000,
+                        "score": 0,
+                        "variations": [{"moves": ["g1f3", "d7d5"], "score": 1000, "mate": 0}],
+                    }
+                }
+            )
+        )
+
+        self.testee.add_picotutor_evaluation(game)
+
+        self.assertEqual([variation.move.uci() for variation in game.variations], ["e2e4", "g1f3"])
+        side_line = game.variations[1]
+        self.assertEqual(side_line.parent, game)
+        self.assertEqual(side_line.variations[0].move.uci(), "d7d5")
+
+    def test_add_picotutor_evaluation_does_not_duplicate_existing_first_move(self):
+        board = chess.Board()
+        user_move = chess.Move.from_uci("e2e4")
+        board.push(user_move)
+        game = chess.pgn.Game.from_board(board)
+        self.testee.set_picotutor(
+            FakePicoTutor(
+                {
+                    (1, user_move, chess.BLACK): {
+                        "nag": chess.pgn.NAG_MISTAKE,
+                        "best_move": "Nf3",
+                        "user_move": "e4",
+                        "CPL": 1000,
+                        "score": 0,
+                        "variations": [{"moves": ["g1f3", "d7d5"], "score": 1000, "mate": 0}],
+                    }
+                }
+            )
+        )
+
+        self.testee.add_picotutor_evaluation(game)
+        self.testee.add_picotutor_evaluation(game)
+
+        self.assertEqual([variation.move.uci() for variation in game.variations], ["e2e4", "g1f3"])
+
+    def test_add_picotutor_evaluation_ignores_invalid_variation_data(self):
+        board = chess.Board()
+        user_move = chess.Move.from_uci("e2e4")
+        board.push(user_move)
+        game = chess.pgn.Game.from_board(board)
+        self.testee.set_picotutor(
+            FakePicoTutor(
+                {
+                    (1, user_move, chess.BLACK): {
+                        "nag": chess.pgn.NAG_MISTAKE,
+                        "best_move": "Nf3",
+                        "user_move": "e4",
+                        "CPL": 1000,
+                        "score": 0,
+                        "variations": [
+                            {"moves": ["not-a-move"], "score": 1000, "mate": 0},
+                            {"moves": ["e7e5"], "score": 900, "mate": 0},
+                        ],
+                    }
+                }
+            )
+        )
+
+        self.testee.add_picotutor_evaluation(game)
+
+        self.assertEqual([variation.move.uci() for variation in game.variations], ["e2e4"])

--- a/tests/test_pgn.py
+++ b/tests/test_pgn.py
@@ -2,6 +2,7 @@ import asyncio
 
 import chess  # type: ignore[import]
 import datetime
+import tempfile
 import unittest
 
 from dgt.util import PlayMode
@@ -37,6 +38,14 @@ class FakePicoTutor:
 
     def get_eval_moves(self):
         return self.eval_moves
+
+
+class FakeEmailer:
+    def __init__(self):
+        self.sent = []
+
+    def send(self, subject, text, file_name):
+        self.sent.append((subject, text, file_name))
 
 
 class TestPgnDisplay(unittest.TestCase):
@@ -170,3 +179,52 @@ class TestPgnDisplay(unittest.TestCase):
         board.push(chess.Move.from_uci("e2e4"))
         board.push(chess.Move.from_uci("e7e5"))
         self.assertFalse(pgn_has_variations(chess.pgn.Game.from_board(board)))
+
+    def test_game_end_duplicate_check_uses_final_pgn_with_variations(self):
+        user_move = chess.Move.from_uci("e2e4")
+        board = chess.Board()
+        board.push(user_move)
+        msg = FakeMessage(board, PlayMode.USER_WHITE)
+        eval_key = (1, user_move, chess.BLACK)
+        emailer = FakeEmailer()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            testee = PgnDisplay(tmpdir + "/games.pgn", emailer, {"headers": {}, "variant": "chess"}, self.loop)
+            testee.last_file_name = tmpdir + "/last_game.pgn"
+
+            testee.set_picotutor(
+                FakePicoTutor(
+                    {
+                        eval_key: {
+                            "nag": chess.pgn.NAG_MISTAKE,
+                            "best_move": "Nf3",
+                            "user_move": "e4",
+                            "CPL": 1000,
+                            "score": 0,
+                            "variations": [{"moves": ["g1f3", "d7d5"], "score": 1000, "mate": 0}],
+                        }
+                    }
+                )
+            )
+            testee._save_and_email_pgn(msg)
+            self.assertEqual(len(emailer.sent), 1)
+
+            testee._save_and_email_pgn(msg)
+            self.assertEqual(len(emailer.sent), 1)
+
+            testee.set_picotutor(
+                FakePicoTutor(
+                    {
+                        eval_key: {
+                            "nag": chess.pgn.NAG_MISTAKE,
+                            "best_move": "Nf3",
+                            "user_move": "e4",
+                            "CPL": 1000,
+                            "score": 0,
+                            "variations": [{"moves": ["g1f3", "e7e5"], "score": 1000, "mate": 0}],
+                        }
+                    }
+                )
+            )
+            testee._save_and_email_pgn(msg)
+            self.assertEqual(len(emailer.sent), 2)

--- a/tests/test_pgn.py
+++ b/tests/test_pgn.py
@@ -8,7 +8,13 @@ import tempfile
 import unittest
 
 from dgt.util import PlayMode
-from pgn import PgnDisplay, add_picotutor_variations_to_game, pgn_has_variations, preserve_loaded_pgn_variations
+from pgn import (
+    PgnDisplay,
+    add_picotutor_variations_to_game,
+    pgn_has_variations,
+    pgn_variation_review_points,
+    preserve_loaded_pgn_variations,
+)
 
 EMPTY_GAME = """[Event "PicoChess Game"]
 [Site "?"]
@@ -181,6 +187,27 @@ class TestPgnDisplay(unittest.TestCase):
         board.push(chess.Move.from_uci("e2e4"))
         board.push(chess.Move.from_uci("e7e5"))
         self.assertFalse(pgn_has_variations(chess.pgn.Game.from_board(board)))
+
+    def test_pgn_variation_review_points_list_mainline_side_variations(self):
+        game = chess.pgn.read_game(io.StringIO("1. e4 e5 2. Nf3 ( 2. Bc4 Nf6 ) Nc6 *"))
+
+        self.assertEqual(
+            pgn_variation_review_points(game),
+            [
+                {
+                    "halfmove": 3,
+                    "target_halfmove": 2,
+                    "move_no": "2.",
+                    "user_move": "Nf3",
+                    "reason": "variation",
+                }
+            ],
+        )
+
+    def test_pgn_variation_review_points_ignore_plain_comments(self):
+        game = chess.pgn.read_game(io.StringIO("1. e4 {Comment only} e5 *"))
+
+        self.assertEqual(pgn_variation_review_points(game), [])
 
     def test_preserve_loaded_pgn_variations_copies_matching_loaded_side_lines(self):
         loaded_game = chess.pgn.read_game(io.StringIO("1. e4 ( 1. Nf3 d5 ) e5 *"))

--- a/tests/test_picochess_analysis_routing.py
+++ b/tests/test_picochess_analysis_routing.py
@@ -7,6 +7,7 @@ from picochess import (
     remote_move_matches_current_position,
     should_show_setpieces_after_lift_timeout,
     should_reject_user_move_after_game_end,
+    should_stop_analysis_after_game_end,
     should_use_tutor_analysis,
     tutor_analysis_allowed_in_mode,
 )
@@ -84,6 +85,60 @@ class TestPicochessAnalysisRouting(unittest.TestCase):
         self.assertFalse(
             should_reject_user_move_after_game_end(
                 interaction_mode=Mode.NORMAL,
+                game_declared=False,
+                game_ending="*",
+            )
+        )
+
+    def test_playing_mode_stops_analysis_after_game_end(self):
+        self.assertTrue(
+            should_stop_analysis_after_game_end(
+                interaction_mode=Mode.NORMAL,
+                game_over=True,
+                game_declared=False,
+                game_ending="*",
+            )
+        )
+        self.assertTrue(
+            should_stop_analysis_after_game_end(
+                interaction_mode=Mode.BRAIN,
+                game_over=False,
+                game_declared=True,
+                game_ending="*",
+            )
+        )
+        self.assertTrue(
+            should_stop_analysis_after_game_end(
+                interaction_mode=Mode.TRAINING,
+                game_over=False,
+                game_declared=False,
+                game_ending="1-0",
+            )
+        )
+
+    def test_non_playing_mode_can_still_analyse_finished_positions(self):
+        self.assertFalse(
+            should_stop_analysis_after_game_end(
+                interaction_mode=Mode.ANALYSIS,
+                game_over=True,
+                game_declared=True,
+                game_ending="0-1",
+            )
+        )
+        self.assertFalse(
+            should_stop_analysis_after_game_end(
+                interaction_mode=Mode.PONDER,
+                game_over=True,
+                game_declared=False,
+                game_ending="1-0",
+            )
+        )
+
+    def test_playing_mode_keeps_analysis_available_during_active_game(self):
+        self.assertFalse(
+            should_stop_analysis_after_game_end(
+                interaction_mode=Mode.NORMAL,
+                game_over=False,
                 game_declared=False,
                 game_ending="*",
             )

--- a/tests/test_picochess_analysis_routing.py
+++ b/tests/test_picochess_analysis_routing.py
@@ -63,6 +63,13 @@ class TestPicochessAnalysisRouting(unittest.TestCase):
                 game_ending="0-1",
             )
         )
+        self.assertTrue(
+            should_reject_user_move_after_game_end(
+                interaction_mode=Mode.REMOTE,
+                game_declared=False,
+                game_ending="0-1",
+            )
+        )
 
     def test_non_playing_mode_can_still_review_after_game_end(self):
         self.assertFalse(

--- a/tests/test_picochess_analysis_routing.py
+++ b/tests/test_picochess_analysis_routing.py
@@ -3,6 +3,7 @@ import unittest
 from dgt.util import Mode
 from picochess import (
     should_show_setpieces_after_lift_timeout,
+    should_reject_user_move_after_game_end,
     should_use_tutor_analysis,
     tutor_analysis_allowed_in_mode,
 )
@@ -43,3 +44,37 @@ class TestPicochessAnalysisRouting(unittest.TestCase):
         self.assertTrue(should_show_setpieces_after_lift_timeout("Q", is_hand_mode=False))
         self.assertFalse(should_show_setpieces_after_lift_timeout("Q", is_hand_mode=True))
         self.assertFalse(should_show_setpieces_after_lift_timeout("", is_hand_mode=False))
+
+    def test_playing_mode_rejects_moves_after_declared_game_end(self):
+        self.assertTrue(
+            should_reject_user_move_after_game_end(
+                interaction_mode=Mode.NORMAL,
+                game_declared=True,
+                game_ending="*",
+            )
+        )
+        self.assertTrue(
+            should_reject_user_move_after_game_end(
+                interaction_mode=Mode.NORMAL,
+                game_declared=False,
+                game_ending="0-1",
+            )
+        )
+
+    def test_non_playing_mode_can_still_review_after_game_end(self):
+        self.assertFalse(
+            should_reject_user_move_after_game_end(
+                interaction_mode=Mode.ANALYSIS,
+                game_declared=True,
+                game_ending="0-1",
+            )
+        )
+
+    def test_playing_mode_accepts_moves_when_game_has_no_result(self):
+        self.assertFalse(
+            should_reject_user_move_after_game_end(
+                interaction_mode=Mode.NORMAL,
+                game_declared=False,
+                game_ending="*",
+            )
+        )

--- a/tests/test_picochess_analysis_routing.py
+++ b/tests/test_picochess_analysis_routing.py
@@ -1,7 +1,10 @@
 import unittest
 
+import chess
+
 from dgt.util import Mode
 from picochess import (
+    remote_move_matches_current_position,
     should_show_setpieces_after_lift_timeout,
     should_reject_user_move_after_game_end,
     should_use_tutor_analysis,
@@ -76,5 +79,33 @@ class TestPicochessAnalysisRouting(unittest.TestCase):
                 interaction_mode=Mode.NORMAL,
                 game_declared=False,
                 game_ending="*",
+            )
+        )
+
+    def test_remote_move_matches_current_live_position(self):
+        board = chess.Board()
+        move = chess.Move.from_uci("e2e4")
+        posted = board.copy()
+        posted.push(move)
+
+        self.assertTrue(remote_move_matches_current_position(move, posted.fen(), board))
+
+    def test_remote_move_rejects_stale_pgn_position(self):
+        live_board = chess.Board()
+        live_board.push(chess.Move.from_uci("e2e4"))
+        live_board.push(chess.Move.from_uci("e7e5"))
+
+        stale_board = chess.Board()
+        move = chess.Move.from_uci("d2d4")
+        stale_board.push(move)
+
+        self.assertFalse(remote_move_matches_current_position(move, stale_board.fen(), live_board))
+
+    def test_remote_move_without_fen_keeps_legacy_acceptance(self):
+        self.assertTrue(
+            remote_move_matches_current_position(
+                chess.Move.from_uci("e2e4"),
+                "",
+                chess.Board(),
             )
         )

--- a/tests/test_picochess_analysis_routing.py
+++ b/tests/test_picochess_analysis_routing.py
@@ -108,6 +108,17 @@ class TestPicochessAnalysisRouting(unittest.TestCase):
 
         self.assertFalse(remote_move_matches_current_position(move, stale_board.fen(), live_board))
 
+    def test_remote_move_rejects_stale_illegal_move(self):
+        live_board = chess.Board()
+        live_board.push(chess.Move.from_uci("e2e4"))
+        live_board.push(chess.Move.from_uci("e7e5"))
+
+        stale_board = chess.Board()
+        move = chess.Move.from_uci("e2e4")
+        stale_board.push(move)
+
+        self.assertFalse(remote_move_matches_current_position(move, stale_board.fen(), live_board))
+
     def test_remote_move_without_fen_keeps_legacy_acceptance(self):
         self.assertTrue(
             remote_move_matches_current_position(

--- a/tests/test_picotutor.py
+++ b/tests/test_picotutor.py
@@ -67,6 +67,106 @@ class TestPicotutor(unittest.TestCase):
             ],
         )
 
+    def test_get_user_move_eval_stores_better_pv_variations(self):
+        tutor = PicoTutor.__new__(PicoTutor)
+        e4 = chess.Move.from_uci("e2e4")
+        nf3 = chess.Move.from_uci("g1f3")
+        tutor.board = chess.Board()
+        tutor.board.push(e4)
+        tutor.coach_on = True
+        tutor.watcher_on = False
+        tutor.evaluated_moves = {}
+        tutor.op = []
+        tutor.hint_move = {chess.WHITE: chess.Move.null(), chess.BLACK: chess.Move.null()}
+        tutor.best_history = {chess.WHITE: [], chess.BLACK: [(0, e4, 0, 0)]}
+        tutor.obvious_history = {chess.WHITE: [], chess.BLACK: [(0, e4, 0, 0)]}
+        tutor.best_moves = {chess.WHITE: [], chess.BLACK: [(1, nf3, 1000, 0), (0, e4, 0, 0)]}
+        tutor.best_info = {
+            chess.WHITE: [],
+            chess.BLACK: [
+                {"pv": [e4, chess.Move.from_uci("e7e5")]},
+                {"pv": [nf3, chess.Move.from_uci("d7d5")]},
+            ],
+        }
+
+        tutor.get_user_move_eval()
+
+        value = tutor.evaluated_moves[(1, e4, chess.BLACK)]
+        self.assertEqual(value["variations"], [{"moves": ["g1f3", "d7d5"], "score": 1000, "mate": 0}])
+
+    def test_get_better_pv_variations_returns_only_higher_ranked_lines(self):
+        tutor = PicoTutor.__new__(PicoTutor)
+        nf3 = chess.Move.from_uci("g1f3")
+        e4 = chess.Move.from_uci("e2e4")
+        d4 = chess.Move.from_uci("d2d4")
+        tutor.best_moves = {
+            chess.WHITE: [(1, nf3, 40, 0), (0, e4, 20, 0), (2, d4, 10, 0)],
+            chess.BLACK: [],
+        }
+        tutor.best_info = {
+            chess.WHITE: [
+                {"pv": [e4, chess.Move.from_uci("e7e5")]},
+                {"pv": [nf3, chess.Move.from_uci("d7d5")]},
+                {"pv": [d4, chess.Move.from_uci("g8f6")]},
+            ],
+            chess.BLACK: [],
+        }
+
+        self.assertEqual(
+            tutor._get_better_pv_variations(chess.WHITE, e4),
+            [{"moves": ["g1f3", "d7d5"], "score": 40, "mate": 0}],
+        )
+
+    def test_get_better_pv_variations_returns_none_when_user_move_is_best(self):
+        tutor = PicoTutor.__new__(PicoTutor)
+        nf3 = chess.Move.from_uci("g1f3")
+        e4 = chess.Move.from_uci("e2e4")
+        tutor.best_moves = {
+            chess.WHITE: [(1, nf3, 40, 0), (0, e4, 20, 0)],
+            chess.BLACK: [],
+        }
+        tutor.best_info = {
+            chess.WHITE: [
+                {"pv": [e4, chess.Move.from_uci("e7e5")]},
+                {"pv": [nf3, chess.Move.from_uci("d7d5")]},
+            ],
+            chess.BLACK: [],
+        }
+
+        self.assertEqual(tutor._get_better_pv_variations(chess.WHITE, nf3), [])
+
+    def test_get_better_pv_variations_caps_missing_user_move_at_three_lines(self):
+        tutor = PicoTutor.__new__(PicoTutor)
+        moves = [
+            chess.Move.from_uci("g1f3"),
+            chess.Move.from_uci("e2e4"),
+            chess.Move.from_uci("d2d4"),
+            chess.Move.from_uci("c2c4"),
+        ]
+        tutor.best_moves = {
+            chess.WHITE: [
+                (0, moves[0], 40, 0),
+                (1, moves[1], 30, 0),
+                (2, moves[2], 20, 0),
+                (3, moves[3], 10, 0),
+            ],
+            chess.BLACK: [],
+        }
+        tutor.best_info = {
+            chess.WHITE: [
+                {"pv": [moves[0], chess.Move.from_uci("d7d5")]},
+                {"pv": [moves[1], chess.Move.from_uci("e7e5")]},
+                {"pv": [moves[2], chess.Move.from_uci("g8f6")]},
+                {"pv": [moves[3], chess.Move.from_uci("e7e6")]},
+            ],
+            chess.BLACK: [],
+        }
+
+        variations = tutor._get_better_pv_variations(chess.WHITE, chess.Move.from_uci("b1c3"))
+
+        self.assertEqual([variation["moves"][0] for variation in variations], ["g1f3", "e2e4", "d2d4"])
+        self.assertEqual(len(variations), 3)
+
 
 class TestPicotutorAnalysisControl(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -7,7 +7,7 @@ import chess
 
 from dgt.api import DgtApi, EventApi, Message
 from dgt.translate import DgtTranslate
-from dgt.util import Mode, PicoCoach, TimeMode
+from dgt.util import GameResult, Mode, PicoCoach, PlayMode, TimeMode
 from server import (
     WebDisplay,
     OBOOKSRV_BOOK_FILE,
@@ -117,6 +117,34 @@ class TestServerWebDisplayTutorCoach(unittest.IsolatedAsyncioTestCase):
 
         self.assertNotIn("brain_hint", shared)
         write_to_clients.assert_any_call({"event": "BrainHint", "squares": []})
+
+
+class TestServerWebDisplayGameEnd(unittest.IsolatedAsyncioTestCase):
+    async def test_game_ends_publishes_inactive_game_before_final_fen(self):
+        board = chess.Board()
+        for move in ("f2f3", "e7e5", "g2g4", "d8h4"):
+            board.push(chess.Move.from_uci(move))
+        shared = {"headers": {}, "system_info": {"game_started": True}}
+        display = WebDisplay(shared, asyncio.get_running_loop())
+
+        with patch("server.EventHandler.write_to_clients") as write_to_clients:
+            await display.task(
+                Message.GAME_ENDS(
+                    tc_init={},
+                    result=GameResult.MATE,
+                    play_mode=PlayMode.USER_WHITE,
+                    game=board,
+                    mode=Mode.NORMAL,
+                )
+            )
+
+        calls = [call.args[0] for call in write_to_clients.call_args_list]
+        self.assertEqual({"event": "SystemInfo", "msg": {"game_started": False}}, calls[0])
+        self.assertEqual("0-1", shared["headers"]["Result"])
+        self.assertEqual("Fen", calls[-1]["event"])
+        self.assertEqual("reload", calls[-1]["play"])
+        self.assertIn("0-1", calls[-1]["pgn"])
+        self.assertFalse(shared["system_info"]["game_started"])
 
 
 class TestServerWebBookSelection(unittest.TestCase):

--- a/upload_pgn.py
+++ b/upload_pgn.py
@@ -73,7 +73,7 @@ class UploadHandler(tornado.web.RequestHandler):
         try:
             with open(upload_file, "wb") as f:
                 f.write(fileinfo["body"])
-                event = Event.READ_GAME(pgn_filename=file_rel_path)
+                event = Event.READ_GAME(pgn_filename=file_rel_path, show_headers=False)
                 await Observable.fire(event)
         except Exception as e:
             self.set_status(500)

--- a/utilities.py
+++ b/utilities.py
@@ -42,7 +42,7 @@ from typing import Optional
 from pathlib import Path
 
 # picochess version
-version = "4.3.2"
+version = "4.3.3"
 
 logger = logging.getLogger(__name__)
 

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -233,6 +233,9 @@ explicitly requires it.
 - Keep OFF automations narrow and defensive. Turning Explore OFF is acceptable
   when entering a playable live position, such as a new game or SET_POSITION,
   so the user is not blocked from making normal web-board moves.
+- When the user explicitly turns Explore OFF, the web client must perform a
+  full live-position sync, equivalent to the Sync button, including restoring
+  the last real move highlight/arrow and discarding explorer-only highlights.
 - Avoid rebuilding a complex Explore state machine. Prefer preserving current
   user intent, explicit user toggles, and the small set of defensive OFF resets.
 

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -219,6 +219,23 @@ explicitly requires it.
 - PGN replay must keep the smart clock control state in sync with replay
   autoplay.
 
+## Web Explore State
+
+- Keep the Explore ON state explicit. In NOEBOARD/web-only play, the Explore
+  button must turn ON only when the user clicks it.
+- When a physical eboard is in use, the web board is an open playground rather
+  than the authoritative move source. In that case Explore may default ON so
+  web-board moves do not affect the physical game unless the user explicitly
+  leaves Explore.
+- PGN move-list navigation, watcher review links, finished-game review, loaded
+  PGNs, result/header updates, and DGT sync/reload paths must not turn Explore
+  ON implicitly. They may preserve Explore if it was already ON.
+- Keep OFF automations narrow and defensive. Turning Explore OFF is acceptable
+  when entering a playable live position, such as a new game or SET_POSITION,
+  so the user is not blocked from making normal web-board moves.
+- Avoid rebuilding a complex Explore state machine. Prefer preserving current
+  user intent, explicit user toggles, and the small set of defensive OFF resets.
+
 ## Merge And Risk Guidance
 
 - Keep web-client commits small and separable from backend game-flow changes.

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -39,6 +39,15 @@ explicitly requires it.
 - Prefer small `/channel` actions that send one backend setting change at a
   time. This avoids flooding audio announcements and makes settings easier to
   reason about.
+- When the web menu changes a setting that is also owned or displayed by the
+  DGT menu, keep the live DGT menu state synchronized before firing backend
+  events. Many backend paths read `state.dgtmenu` rather than re-reading
+  `picochess.ini`, and users may mix DGT clock menu changes with mobile web
+  menu changes during one PicoChess run.
+- For those shared settings, update all applicable layers together:
+  `picochess.ini` for persistence, the live runtime value read by backend
+  logic, and the DGT menu's cached/current selection fields used for clock menu
+  display.
 
 ## Playing Mode Naming
 

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -259,6 +259,10 @@ explicitly requires it.
 - Keep OFF automations narrow and defensive. Turning Explore OFF is acceptable
   when entering a playable live position, such as a new game or SET_POSITION,
   so the user is not blocked from making normal web-board moves.
+- Outside an active game, PGN review and browser-side exploration are allowed to
+  be loose. Starting a new game is the reset back to live move-entry state:
+  Explore OFF, live PGN tree active, and normal move submission allowed
+  according to NOEBOARD/REMOTE/eboard rules.
 - When the user explicitly turns Explore OFF, the web client must perform a
   full live-position sync, equivalent to the Sync button, including restoring
   the last real move highlight/arrow and discarding explorer-only highlights.

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -230,6 +230,10 @@ explicitly requires it.
 - In normal physical-eboard play, the backend must not accept web-board moves
   as real game moves. The frontend should also default to the eboard-safe path
   when board authority is unknown or stale.
+- With a physical eboard and Explore OFF, the web board should be read-only in
+  normal play. Do not update the browser PGN or post a move to the backend from
+  a board drag unless the client is explicitly in NOEBOARD or the `Mode.REMOTE`
+  exception below applies.
 - `Mode.REMOTE` is the intentional exception: one player uses the physical
   eboard and the remote opponent uses the web board. With Explore OFF, the web
   client may submit real moves only for the remote side's turn; local-side moves

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -227,6 +227,17 @@ explicitly requires it.
   than the authoritative move source. In that case Explore may default ON so
   web-board moves do not affect the physical game unless the user explicitly
   leaves Explore.
+- In normal physical-eboard play, the backend must not accept web-board moves
+  as real game moves. The frontend should also default to the eboard-safe path
+  when board authority is unknown or stale.
+- `Mode.REMOTE` is the intentional exception: one player uses the physical
+  eboard and the remote opponent uses the web board. With Explore OFF, the web
+  client may submit real moves only for the remote side's turn; local-side moves
+  still come from the eboard.
+- Because `Mode.REMOTE` uses the web board as a real move-entry surface, it
+  should behave like NOEBOARD for the remote side: do not auto-set Explore ON
+  just because a physical eboard exists, and keep the board playable only for
+  the remote side to move.
 - PGN move-list navigation, watcher review links, finished-game review, loaded
   PGNs, result/header updates, and DGT sync/reload paths must not turn Explore
   ON implicitly. They may preserve Explore if it was already ON.

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -234,6 +234,11 @@ explicitly requires it.
   normal play. Do not update the browser PGN or post a move to the backend from
   a board drag unless the client is explicitly in NOEBOARD or the `Mode.REMOTE`
   exception below applies.
+- Track whether the loaded PGN tree is the live PicoChess game tree separately
+  from the selected FEN. Database games, watcher/PGN review, and live gameplay
+  can show the same board position while having different move-entry authority.
+  Use that state to guard web-board move submission and to highlight Sync when
+  the user is away from live move entry.
 - `Mode.REMOTE` is the intentional exception: one player uses the physical
   eboard and the remote opponent uses the web board. With Explore OFF, the web
   client may submit real moves only for the remote side's turn; local-side moves

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -137,9 +137,10 @@ explicitly requires it.
 ## Tutor Menu
 
 - The new Tutor menu should send only the changed setting.
-- Keep the quick combined Tutor toggle in the old `ANALYSES` tab. It is useful
-  for switching between Tutor analysis and selected-engine analysis, and for
-  PGN replay timing.
+- Tutor state is controlled from the overlay Tutor menu. Do not reintroduce the
+  old quick combined Tutor toggle in the `ANALYSES` tab; that toolbar should
+  stay focused on analysis visibility, variation visibility, Web Stockfish, and
+  Explore controls.
 - Coach is one mutually exclusive setting: `off`, `on`, `lift`, `brain`, or
   `hand`. Do not model Brain and Hand as independent toggles.
 - Brain/Hand are tutor coach modes for normal play, not web-only modes.

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -241,8 +241,10 @@ explicitly requires it.
 - Track whether the loaded PGN tree is the live PicoChess game tree separately
   from the selected FEN. Database games, watcher/PGN review, and live gameplay
   can show the same board position while having different move-entry authority.
-  Use that state to guard web-board move submission and to highlight Sync when
-  the user is away from live move entry.
+  Use that state to guard web-board move submission. Highlight Sync only during
+  an active game when the user is away from live move entry; finished-game and
+  loaded-PGN review should not show amber just because there is no active game
+  to continue.
 - `Mode.REMOTE` is the intentional exception: one player uses the physical
   eboard and the remote opponent uses the web board. With Explore OFF, the web
   client may submit real moves only for the remote side's turn; local-side moves

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -241,10 +241,11 @@ explicitly requires it.
 - Track whether the loaded PGN tree is the live PicoChess game tree separately
   from the selected FEN. Database games, watcher/PGN review, and live gameplay
   can show the same board position while having different move-entry authority.
-  Use that state to guard web-board move submission. Highlight Sync only during
-  an active game when the user is away from live move entry; finished-game and
-  loaded-PGN review should not show amber just because there is no active game
-  to continue.
+  Use that state to guard web-board move submission. Highlight Sync only when
+  there is an active game, the web board is a real move-entry surface
+  (NOEBOARD or `Mode.REMOTE`), and the user is away from live move entry.
+  Finished-game review, loaded-PGN review, and normal physical-eboard play
+  should not show amber just because the browser board differs from live play.
 - `Mode.REMOTE` is the intentional exception: one player uses the physical
   eboard and the remote opponent uses the web board. With Explore OFF, the web
   client may submit real moves only for the remote side's turn; local-side moves

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -151,6 +151,9 @@ explicitly requires it.
   `E` for selected-engine backend analysis and `T` for Tutor backend analysis.
 - Read and display backend tutor state when the web client opens, and keep it in
   sync via websocket updates.
+- When a PGN is loaded from disk, the WATCHER list may show lightweight review
+  points derived from mainline side variations. Do not recreate or persist
+  `PicoTutor.evaluated_moves` from PGN comments or old evaluation details.
 
 ## ANALYSES Tab CPU
 

--- a/web/picoweb/static/css/base.css
+++ b/web/picoweb/static/css/base.css
@@ -33,6 +33,11 @@ body {
     font-weight: normal;
 }
 
+#pgn.pgn-variations-hidden .gameVariation,
+#pgn.pgn-variations-hidden .gameComment {
+    display: none;
+}
+
 .comment {
     font-size: max(1.5vw, 1.1rem);
     display: block;

--- a/web/picoweb/static/css/base.css
+++ b/web/picoweb/static/css/base.css
@@ -248,6 +248,20 @@ div.dataTables_wrapper div.dataTables_length select {
     padding: 8px max(4px, 1vw);
 }
 
+#DgtSyncBtn.sync-attention {
+    background: linear-gradient(145deg, #f59e0b, #d97706) !important;
+    border-color: #b45309 !important;
+    color: #111827 !important;
+    box-shadow: 0 0 0 2px rgba(245, 158, 11, 0.35) !important;
+}
+
+#DgtSyncBtn.sync-attention:hover,
+#DgtSyncBtn.sync-attention:focus-visible {
+    background: linear-gradient(145deg, #fbbf24, #f59e0b) !important;
+    border-color: #92400e !important;
+    color: #111827 !important;
+}
+
 .nav-link.engine-mode-button {
     display: inline-flex;
     align-items: center;

--- a/web/picoweb/static/js/app.js
+++ b/web/picoweb/static/js/app.js
@@ -635,12 +635,17 @@ function isLiveMoveEntryPosition() {
     return livePgnTreeActive && isCurrentPicoLivePosition();
 }
 
+function isPicoGameActive() {
+    var sysInfo = window._picoSystemInfo || {};
+    return Object.prototype.hasOwnProperty.call(sysInfo, 'game_started') && Boolean(sysInfo.game_started);
+}
+
 function updateSyncButtonAttention() {
     var btn = document.getElementById('DgtSyncBtn');
     if (!btn) {
         return;
     }
-    var needsSync = webExploreMode || !isLiveMoveEntryPosition();
+    var needsSync = isPicoGameActive() && (webExploreMode || !isLiveMoveEntryPosition());
     btn.classList.toggle('sync-attention', needsSync);
     btn.title = needsSync ? 'Sync with live game' : 'Sync with DGT board';
     btn.setAttribute('aria-label', btn.title);

--- a/web/picoweb/static/js/app.js
+++ b/web/picoweb/static/js/app.js
@@ -643,6 +643,21 @@ function shouldAutoExploreWebClientAction() {
     return !!psi.has_board && psi.interaction_mode !== 'remote';
 }
 
+function canSubmitWebBoardMove(movingColor) {
+    var psi = window._picoSystemInfo || {};
+    if (!isCurrentPicoLivePosition() || !Object.prototype.hasOwnProperty.call(psi, 'has_board')) {
+        return false;
+    }
+    if (!psi.has_board) {
+        return true;
+    }
+    if (psi.interaction_mode === 'remote') {
+        var remoteColor = (psi.play_mode === 'user_white') ? 'black' : 'white';
+        return movingColor === remoteColor;
+    }
+    return false;
+}
+
 function shouldAutoExplorePgnSelection() {
     // PGN navigation is review-only. Keep Explore explicit so browser-side
     // moves and Web Stockfish analysis cannot start from a move-list click.
@@ -1259,6 +1274,7 @@ function toColor(chess) {
 
 var onSnapEnd = async function (source, target) {
     var tmpGame = createGamePointer();
+    var movingColor = toColor(tmpGame);
 
     if (!currentPosition) {
         currentPosition = {};
@@ -1280,8 +1296,14 @@ var onSnapEnd = async function (source, target) {
         return;
     }
 
-    if (webExploreMode || shouldAutoExploreWebClientAction()) {
+    if (webExploreMode) {
         startWebExploreFromGame(tmpGame, false);
+        updateChessGround();
+        updateStatus();
+        return;
+    }
+
+    if (!canSubmitWebBoardMove(movingColor)) {
         updateChessGround();
         updateStatus();
         return;
@@ -1329,28 +1351,16 @@ async function getMove(game, source, target) {
 
 function updateChessGround() {
     var tmpGame = createGamePointer();
-    var psi = window._picoSystemInfo || {};
-    var hasBoard = !!psi.has_board;
     var turnColor = toColor(tmpGame);
     var movableColor;
 
     if (webExploreMode) {
         movableColor = turnColor;
-    } else if (!hasBoard && isCurrentPicoLivePosition()) {
-        // No physical board: full diagram interactivity (NOEBOARD mode).
-        movableColor = turnColor;
-    } else if (psi.interaction_mode === 'remote') {
-        // REMOTE mode: local player uses the physical board; the remote
-        // opponent enters moves via the web diagram.  Only allow dragging
-        // when it is actually the remote side's turn.
-        var remoteColor = (psi.play_mode === 'user_white') ? 'black' : 'white';
-        movableColor = (turnColor === remoteColor) ? remoteColor : 'none';
-    } else if (hasBoard) {
-        // Physical board users may use the web diagram as a local playground.
-        // Legal web moves auto-enter Explore and are never sent as game moves.
+    } else if (canSubmitWebBoardMove(turnColor)) {
+        // NOEBOARD and REMOTE mode use the web board as a real move-entry surface.
         movableColor = turnColor;
     } else {
-        // Fallback: keep the diagram read-only.
+        // Physical eboard users need Explore ON before browser-side moves are playable.
         movableColor = 'none';
     }
 

--- a/web/picoweb/static/js/app.js
+++ b/web/picoweb/static/js/app.js
@@ -633,6 +633,11 @@ function syncToCurrentPicoLivePosition() {
     return false;
 }
 
+function shouldAutoExplorePgnSelection() {
+    var psi = window._picoSystemInfo || {};
+    return !!psi.has_board && psi.interaction_mode !== 'remote';
+}
+
 function updateWebExploreButton() {
     var btn = document.getElementById('webExploreToggleBtn');
     if (!btn) {
@@ -659,6 +664,16 @@ function setWebExploreMode(enabled, redraw) {
         webExploreGame = null;
         syncToCurrentPicoLivePosition();
     }
+    updateWebExploreButton();
+    if (redraw !== false) {
+        updateChessGround();
+        updateStatus();
+    }
+}
+
+function startWebExploreFromCurrentPosition(redraw) {
+    webExploreGame = createPositionGamePointer();
+    webExploreMode = true;
     updateWebExploreButton();
     if (redraw !== false) {
         updateChessGround();
@@ -1653,15 +1668,20 @@ function clockShowHint() {
     clockButton3();
 }
 
-function goToPosition(fen) {
-    stopWebExploreMode(false);
+function goToPosition(fen, options) {
+    options = options || {};
+    if (!options.preserveExplore) {
+        stopWebExploreMode(false);
+    }
     stopAnalysis();
     currentPosition = fenHash[fen];
     if (!currentPosition) {
         return false;
     }
-    updateChessGround();
-    updateStatus();
+    if (options.redraw !== false) {
+        updateChessGround();
+        updateStatus();
+    }
     return true;
 }
 
@@ -1670,7 +1690,10 @@ function goToGameFen(event) {
         event.preventDefault();
     }
     var fen = $(this).attr('data-fen');
-    goToPosition(fen);
+    var autoExplore = shouldAutoExplorePgnSelection();
+    if (goToPosition(fen, { preserveExplore: autoExplore, redraw: !autoExplore }) && autoExplore) {
+        startWebExploreFromCurrentPosition();
+    }
     removeHighlights();
     return false;
 }

--- a/web/picoweb/static/js/app.js
+++ b/web/picoweb/static/js/app.js
@@ -615,6 +615,16 @@ function createGamePointer() {
     return createPositionGamePointer();
 }
 
+function isCurrentPicoLivePosition() {
+    if (!currentPosition) {
+        return false;
+    }
+    if (!fenHash || !fenHash.last) {
+        return true;
+    }
+    return currentPosition === fenHash.last || currentPosition.fen === fenHash.last.fen;
+}
+
 function updateWebExploreButton() {
     var btn = document.getElementById('webExploreToggleBtn');
     if (!btn) {
@@ -1166,6 +1176,12 @@ var onSnapEnd = async function (source, target) {
         gameHistory.result = '*';
     }
 
+    if (!webExploreMode && !isCurrentPicoLivePosition()) {
+        updateChessGround();
+        updateStatus();
+        return;
+    }
+
     var move = await getMove(tmpGame, source, target);
     if (!move) {
         updateChessGround();
@@ -1228,7 +1244,7 @@ function updateChessGround() {
 
     if (webExploreMode) {
         movableColor = turnColor;
-    } else if (!hasBoard) {
+    } else if (!hasBoard && isCurrentPicoLivePosition()) {
         // No physical board: full diagram interactivity (NOEBOARD mode).
         movableColor = turnColor;
     } else if (psi.interaction_mode === 'remote') {

--- a/web/picoweb/static/js/app.js
+++ b/web/picoweb/static/js/app.js
@@ -674,6 +674,11 @@ function stripFen(fen) {
     return strippedFen;
 }
 
+function isDefinitiveResult(result) {
+    result = String(result || '').trim();
+    return result === '1-0' || result === '0-1' || result === '1/2-1/2';
+}
+
 String.prototype.trim = function () {
     return this.replace(/\s*$/g, '');
 };
@@ -2281,8 +2286,7 @@ function formatTutorMistakeImpact(item) {
 }
 
 function hasDefinitiveGameResult() {
-    var result = String((gameHistory && gameHistory.result) || '').trim();
-    return result === '1-0' || result === '0-1' || result === '1/2-1/2';
+    return isDefinitiveResult((gameHistory && gameHistory.result) || '');
 }
 
 function canReviewTutorMistakes() {
@@ -3273,10 +3277,13 @@ $(function () {
                     case 'Header':
                         setHeaders(data['headers']);
                         // Definitive result means game ended
-                        if (window.setPicoGameActive) {
-                            var _res = data['headers'] && data['headers']['Result'];
-                            if (_res === '1-0' || _res === '0-1' || _res === '1/2-1/2') {
+                        var _res = data['headers'] && data['headers']['Result'];
+                        if (isDefinitiveResult(_res)) {
+                            if (window.setPicoGameActive) {
                                 window.setPicoGameActive(false);
+                            }
+                            if (!webExploreMode) {
+                                setWebExploreMode(true);
                             }
                         }
                         break;

--- a/web/picoweb/static/js/app.js
+++ b/web/picoweb/static/js/app.js
@@ -1382,7 +1382,8 @@ function addNewMove(m, current_position, fen, props) {
     node.move = m.move;
     node.previous = current_position;
     node.nags = [];
-    node.is_mainline = !current_position || !current_position.variations || current_position.variations.length === 0;
+    var parentIsMainline = !current_position || !current_position.previous || Boolean(current_position.is_mainline);
+    node.is_mainline = parentIsMainline && (!current_position || !current_position.variations || current_position.variations.length === 0);
     if (props) {
         if (props.comment) {
             node.comment = props.comment;

--- a/web/picoweb/static/js/app.js
+++ b/web/picoweb/static/js/app.js
@@ -625,6 +625,14 @@ function isCurrentPicoLivePosition() {
     return currentPosition === fenHash.last || currentPosition.fen === fenHash.last.fen;
 }
 
+function syncToCurrentPicoLivePosition() {
+    if (fenHash && fenHash.last) {
+        currentPosition = fenHash.last;
+        return true;
+    }
+    return false;
+}
+
 function updateWebExploreButton() {
     var btn = document.getElementById('webExploreToggleBtn');
     if (!btn) {
@@ -649,6 +657,7 @@ function setWebExploreMode(enabled, redraw) {
     } else {
         webExploreMode = false;
         webExploreGame = null;
+        syncToCurrentPicoLivePosition();
     }
     updateWebExploreButton();
     if (redraw !== false) {

--- a/web/picoweb/static/js/app.js
+++ b/web/picoweb/static/js/app.js
@@ -1038,7 +1038,8 @@ function cloneMainlineToNode(node) {
             previous: target,
             nags: [],
             variations: [],
-            half_move_num: source.half_move_num
+            half_move_num: source.half_move_num,
+            is_mainline: true
         };
         target.variations = [copy];
         target = copy;
@@ -1353,6 +1354,7 @@ function addNewMove(m, current_position, fen, props) {
     node.move = m.move;
     node.previous = current_position;
     node.nags = [];
+    node.is_mainline = !current_position || !current_position.variations || current_position.variations.length === 0;
     if (props) {
         if (props.comment) {
             node.comment = props.comment;
@@ -2460,6 +2462,9 @@ function findFenByHalfmove(halfmove) {
         }
         var node = fenHash[key];
         if (!node || typeof node !== 'object') {
+            continue;
+        }
+        if (!node.is_mainline) {
             continue;
         }
         if (node.half_move_num === target) {

--- a/web/picoweb/static/js/app.js
+++ b/web/picoweb/static/js/app.js
@@ -960,6 +960,11 @@ function buildPgnPrefixForNode(node) {
 
 function writeVariationTree(dom, gameMoves, gameHistoryEl) {
     $(dom).html(gameHistoryEl.gameHeader + '<div class="gameMoves">' + gameMoves + ' <span class="gameResult">' + gameHistoryEl.result + '</span></div>');
+    bindPgnFenLinks();
+}
+
+function bindPgnFenLinks() {
+    $('.fen').off('click', goToGameFen).on('click', goToGameFen);
 }
 
 // update the board position after the piece snap
@@ -985,7 +990,7 @@ function updateCurrentPosition(move, tmpGame) {
 
 var updateStatus = function () {
     var status = '';
-    $('.fen').unbind('click', goToGameFen).one('click', goToGameFen);
+    bindPgnFenLinks();
 
     var moveColor = 'White';
     var tmpGame = createGamePointer();
@@ -1402,7 +1407,7 @@ function loadGame(pgn_lines) {
         currentPosition = fenHash[curr_fen];
     }
     setHeaders(game_headers);
-    $('.fen').unbind('click', goToGameFen).one('click', goToGameFen);
+    bindPgnFenLinks();
 }
 
 function getFullGame() {
@@ -1541,10 +1546,14 @@ function goToPosition(fen) {
     return true;
 }
 
-function goToGameFen() {
+function goToGameFen(event) {
+    if (event) {
+        event.preventDefault();
+    }
     var fen = $(this).attr('data-fen');
     goToPosition(fen);
     removeHighlights();
+    return false;
 }
 
 function setPositionFromCurrentPgn() {

--- a/web/picoweb/static/js/app.js
+++ b/web/picoweb/static/js/app.js
@@ -633,9 +633,13 @@ function syncToCurrentPicoLivePosition() {
     return false;
 }
 
-function shouldAutoExplorePgnSelection() {
+function shouldAutoExploreWebClientAction() {
     var psi = window._picoSystemInfo || {};
     return !!psi.has_board && psi.interaction_mode !== 'remote';
+}
+
+function shouldAutoExplorePgnSelection() {
+    return shouldAutoExploreWebClientAction();
 }
 
 function updateWebExploreButton() {
@@ -673,6 +677,16 @@ function setWebExploreMode(enabled, redraw) {
 
 function startWebExploreFromCurrentPosition(redraw) {
     webExploreGame = createPositionGamePointer();
+    webExploreMode = true;
+    updateWebExploreButton();
+    if (redraw !== false) {
+        updateChessGround();
+        updateStatus();
+    }
+}
+
+function startWebExploreFromGame(game, redraw) {
+    webExploreGame = new Chess(game.fen(), chessGameType);
     webExploreMode = true;
     updateWebExploreButton();
     if (redraw !== false) {
@@ -1221,8 +1235,8 @@ var onSnapEnd = async function (source, target) {
         return;
     }
 
-    if (webExploreMode) {
-        webExploreGame = tmpGame;
+    if (webExploreMode || shouldAutoExploreWebClientAction()) {
+        startWebExploreFromGame(tmpGame, false);
         updateChessGround();
         updateStatus();
         return;
@@ -1286,8 +1300,12 @@ function updateChessGround() {
         // when it is actually the remote side's turn.
         var remoteColor = (psi.play_mode === 'user_white') ? 'black' : 'white';
         movableColor = (turnColor === remoteColor) ? remoteColor : 'none';
+    } else if (hasBoard) {
+        // Physical board users may use the web diagram as a local playground.
+        // Legal web moves auto-enter Explore and are never sent as game moves.
+        movableColor = turnColor;
     } else {
-        // Any other mode with a board: diagram is read-only.
+        // Fallback: keep the diagram read-only.
         movableColor = 'none';
     }
 
@@ -2451,7 +2469,13 @@ function goToHalfmove(halfmove) {
     if (!fen) {
         return false;
     }
-    goToPosition(fen);
+    var autoExplore = shouldAutoExplorePgnSelection();
+    if (!goToPosition(fen, { preserveExplore: autoExplore, redraw: !autoExplore })) {
+        return false;
+    }
+    if (autoExplore) {
+        startWebExploreFromCurrentPosition();
+    }
     removeHighlights();
     return true;
 }

--- a/web/picoweb/static/js/app.js
+++ b/web/picoweb/static/js/app.js
@@ -688,6 +688,10 @@ function stopWebExploreMode(redraw) {
     setWebExploreMode(false, redraw);
 }
 
+function resetWebExploreForPlayablePosition() {
+    stopWebExploreMode(false);
+}
+
 function toggleWebExploreMode() {
     setWebExploreMode(!webExploreMode);
 }
@@ -3200,6 +3204,7 @@ $(function () {
                         }
                         break;
                     case 'Game':
+                        resetWebExploreForPlayablePosition();
                         _tutorMoveActive = false;
                         clearBrainHint();
                         stopAnalysisClock();

--- a/web/picoweb/static/js/app.js
+++ b/web/picoweb/static/js/app.js
@@ -727,7 +727,12 @@ function resetWebExploreForPlayablePosition() {
 }
 
 function toggleWebExploreMode() {
-    setWebExploreMode(!webExploreMode);
+    if (webExploreMode) {
+        stopWebExploreMode(false);
+        goToDGTFen();
+    } else {
+        setWebExploreMode(true);
+    }
 }
 
 function stripFen(fen) {

--- a/web/picoweb/static/js/app.js
+++ b/web/picoweb/static/js/app.js
@@ -2292,6 +2292,9 @@ function updateDGTPosition(data) {
         }
         return;
     }
+    if (data.pgn && !isSameGameAsPgn(data.pgn)) {
+        loadGame(data.pgn.split("\n"));
+    }
     if (!goToPosition(data.fen, { preserveExplore: preserveExplore })) {
         loadGame(data['pgn'].split("\n"));
         if (!goToPosition(data.fen, { preserveExplore: preserveExplore })) {
@@ -2332,6 +2335,26 @@ function forcePosition(fen) {
     }
     updateChessGround();
     updateStatus();
+}
+
+function getPgnMoveText(pgn) {
+    if (!pgn) {
+        return '';
+    }
+    return pgn
+        .replace(/\[.*?\][\r\n]*/g, ' ')
+        .replace(/\{[\s\S]*?\}/g, ' ')
+        .replace(/\$[0-9]+/g, ' ')
+        .replace(/[()]/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+}
+
+function isSameGameAsPgn(pgnText) {
+    if (!pgnText || !gameHistory) {
+        return false;
+    }
+    return getPgnMoveText(getFullGame()) === getPgnMoveText(pgnText);
 }
 
 function formatTutorMistakeImpact(item) {
@@ -2926,6 +2949,7 @@ function updateBackendAnalysis(analysis) {
 }
 
 function goToDGTFen() {
+    stopWebExploreMode(false);
     $.get('/dgt', { action: 'get_last_move' }, function (data) {
         if (data && data.fen) {
             if (data.play === 'newgame') {

--- a/web/picoweb/static/js/app.js
+++ b/web/picoweb/static/js/app.js
@@ -685,6 +685,11 @@ function startWebExploreFromCurrentPosition(redraw) {
     }
 }
 
+function startWebExploreFromLivePosition(redraw) {
+    syncToCurrentPicoLivePosition();
+    startWebExploreFromCurrentPosition(redraw);
+}
+
 function startWebExploreFromGame(game, redraw) {
     webExploreGame = new Chess(game.fen(), chessGameType);
     webExploreMode = true;
@@ -3343,9 +3348,7 @@ $(function () {
                             if (window.setPicoGameActive) {
                                 window.setPicoGameActive(false);
                             }
-                            if (!webExploreMode) {
-                                setWebExploreMode(true);
-                            }
+                            startWebExploreFromLivePosition();
                         }
                         break;
                     case 'Title':

--- a/web/picoweb/static/js/app.js
+++ b/web/picoweb/static/js/app.js
@@ -314,6 +314,10 @@ var pgnVariationsVisible = false;
 var webExploreMode = false;
 var webExploreGame = null;
 var webExploreBoardPolicyInitialized = false;
+var webAnalysisSearchActive = false;
+var webAnalysisStopRequested = false;
+var webAnalysisStopReasserted = false;
+var webAnalysisPendingRequest = null;
 
 fenHash = {};
 
@@ -2124,11 +2128,71 @@ function stockfishPNACLModuleDidLoad() {
 function handleCrash(event) {
     console.warn('Nacl Module crash handler method');
     console.warn(event);
+    resetWebAnalysisSearchState();
     loadNaclStockfish();
+}
+
+function resetWebAnalysisSearchState() {
+    webAnalysisSearchActive = false;
+    webAnalysisStopRequested = false;
+    webAnalysisStopReasserted = false;
+    webAnalysisPendingRequest = null;
+}
+
+function startWebAnalysisRequest(request) {
+    if (!window.stockfish || !request) {
+        return;
+    }
+    webAnalysisSearchActive = true;
+    webAnalysisStopRequested = false;
+    webAnalysisStopReasserted = false;
+    webAnalysisPendingRequest = null;
+    window.stockfish.postMessage(request.positionCommand);
+    window.stockfish.postMessage('setoption name multipv value ' + request.multipv);
+    window.stockfish.postMessage('go infinite');
+}
+
+function queueWebAnalysisRequest(request, positionUpdate) {
+    if (positionUpdate && webAnalysisSearchActive) {
+        webAnalysisPendingRequest = request;
+        if (!webAnalysisStopRequested && window.stockfish) {
+            webAnalysisStopRequested = true;
+            webAnalysisStopReasserted = false;
+            window.stockfish.postMessage('stop');
+        }
+        return;
+    }
+    startWebAnalysisRequest(request);
+}
+
+function handleWebAnalysisControlMessage(line) {
+    line = String(line || '').trim();
+    if (webAnalysisStopRequested && !webAnalysisStopReasserted && line.indexOf('info ') === 0) {
+        // The first stop can arrive before a newly-created worker has started
+        // its queued search. Reassert it once analysis output proves it is live.
+        webAnalysisStopReasserted = true;
+        if (window.stockfish) {
+            window.stockfish.postMessage('stop');
+        }
+    }
+    if (line.indexOf('bestmove ') !== 0) {
+        return webAnalysisPendingRequest !== null && line.indexOf('info ') === 0;
+    }
+
+    var nextRequest = webAnalysisPendingRequest;
+    webAnalysisSearchActive = false;
+    webAnalysisStopRequested = false;
+    webAnalysisStopReasserted = false;
+    webAnalysisPendingRequest = null;
+    if (window.analysis && nextRequest) {
+        startWebAnalysisRequest(nextRequest);
+    }
+    return true;
 }
 
 function handleMessage(event) {
     if (!event || !event.data) return;
+    if (handleWebAnalysisControlMessage(event.data)) return;
     var output = formatEngineOutput(event.data);
     if (output && output.pv_index === 1) {
         // Update the static SF18 first-PV row with the same compact PV layout
@@ -2172,6 +2236,7 @@ function stopAnalysis() {
             console.warn(err);
         }
     }
+    resetWebAnalysisSearchState();
 
     // Clear extra PV lines (pv_2+); pv_1 is now static HTML in sf18Row
     $('#pv_output').empty();
@@ -2266,16 +2331,14 @@ function analyze(position_update) {
     if (!webExploreMode && setupBoardFen !== START_FEN) {
         startpos = 'fen ' + setupBoardFen;
     }
-    if (position_update && window.stockfish) {
-        window.stockfish.postMessage('stop');
-    }
     var positionCommand = 'position ' + startpos;
     if (moves && moves.trim()) {
         positionCommand += ' moves ' + moves;
     }
-    window.stockfish.postMessage(positionCommand);
-    window.stockfish.postMessage('setoption name multipv value ' + window.multipv);
-    window.stockfish.postMessage('go infinite');
+    queueWebAnalysisRequest(
+        { positionCommand: positionCommand, multipv: window.multipv },
+        position_update
+    );
 }
 
 function updateDGTPosition(data) {

--- a/web/picoweb/static/js/app.js
+++ b/web/picoweb/static/js/app.js
@@ -2876,6 +2876,44 @@ function updateBackendAnalysisLine(analysis) {
 var analysisDisplayVisible = false;
 var lastServerAnalysis = null;
 var lastServerAnalysisKey = null;
+var lastServerAnalysisBySource = {
+    engine: null,
+    tutor: null
+};
+
+function backendAnalysisSource(analysis) {
+    return String((analysis && analysis.source) || 'engine').toLowerCase() === 'tutor'
+        ? 'tutor'
+        : 'engine';
+}
+
+function isTutorBackendAnalysisPreferred() {
+    var settings = window._picoTutorSettings || {};
+    var coach = String(settings.tutor_coach || 'off').toLowerCase();
+    return Boolean(settings.tutor_active || settings.tutor_watcher || coach !== 'off');
+}
+
+function analysisFenMatches(reference, candidate) {
+    if (!candidate) return false;
+    var referenceFen = (reference && reference.fen) || (currentPosition && currentPosition.fen) || '';
+    if (!referenceFen || !candidate.fen) return true;
+    return candidate.fen === referenceFen;
+}
+
+function preferredBackendAnalysis(reference) {
+    var tutorAnalysis = lastServerAnalysisBySource.tutor;
+    var engineAnalysis = lastServerAnalysisBySource.engine;
+    if (isTutorBackendAnalysisPreferred() && analysisFenMatches(reference, tutorAnalysis)) {
+        return tutorAnalysis;
+    }
+    if (analysisFenMatches(reference, engineAnalysis)) {
+        return engineAnalysis;
+    }
+    if (analysisFenMatches(reference, tutorAnalysis)) {
+        return tutorAnalysis;
+    }
+    return reference || engineAnalysis || tutorAnalysis || null;
+}
 
 function backendAnalysisKey(analysis) {
     if (!analysis) {
@@ -3051,6 +3089,8 @@ function updateBackendAnalysis(analysis) {
     if (!analysis) {
         lastServerAnalysis = null;
         lastServerAnalysisKey = null;
+        lastServerAnalysisBySource.engine = null;
+        lastServerAnalysisBySource.tutor = null;
         updateBackendAnalysisSourceBadge('engine');
         // Clear content but keep button state
         var metaEl = document.getElementById('engineMeta');
@@ -3061,20 +3101,30 @@ function updateBackendAnalysis(analysis) {
     }
     // Upstream: explicit clear signal resets the engine line to placeholder state.
     if (analysis.clear) {
-        lastServerAnalysisKey = null;
-        updateBackendAnalysisSourceBadge(analysis.source);
-        setEngineLinePlaceholder();
+        lastServerAnalysisBySource[backendAnalysisSource(analysis)] = null;
+        var remainingAnalysis = preferredBackendAnalysis(null);
+        var remainingKey = backendAnalysisKey(remainingAnalysis);
+        var remainingUnchanged = remainingKey === lastServerAnalysisKey;
+        lastServerAnalysis = remainingAnalysis;
+        lastServerAnalysisKey = remainingKey;
+        if (!remainingAnalysis) {
+            updateBackendAnalysisSourceBadge(analysis.source);
+            setEngineLinePlaceholder();
+        } else if (analysisDisplayVisible && !remainingUnchanged) {
+            updateBackendAnalysisLine(remainingAnalysis);
+        }
         return;
     }
-    var analysisKey = backendAnalysisKey(analysis);
+    lastServerAnalysisBySource[backendAnalysisSource(analysis)] = analysis;
+    var displayAnalysis = preferredBackendAnalysis(analysis);
+    var analysisKey = backendAnalysisKey(displayAnalysis);
     var unchanged = analysisKey === lastServerAnalysisKey;
-    lastServerAnalysis = analysis;
+    lastServerAnalysis = displayAnalysis;
     lastServerAnalysisKey = analysisKey;
-    updateBackendAnalysisSourceBadge(analysis.source);
     if (!analysisDisplayVisible || unchanged) {
         return;
     }
-    updateBackendAnalysisLine(analysis);
+    updateBackendAnalysisLine(displayAnalysis);
 }
 
 function goToDGTFen() {

--- a/web/picoweb/static/js/app.js
+++ b/web/picoweb/static/js/app.js
@@ -310,6 +310,7 @@ const SERVER_NAME = location.hostname
 // Opening book and games database servers
 const BOOK_SERVER_PREFIX = ''; // same origin
 const GAMES_SERVER_PREFIX = 'http://' + SERVER_NAME + ':7778';
+var pgnVariationsVisible = false;
 
 fenHash = {};
 
@@ -961,10 +962,27 @@ function buildPgnPrefixForNode(node) {
 function writeVariationTree(dom, gameMoves, gameHistoryEl) {
     $(dom).html(gameHistoryEl.gameHeader + '<div class="gameMoves">' + gameMoves + ' <span class="gameResult">' + gameHistoryEl.result + '</span></div>');
     bindPgnFenLinks();
+    applyPgnVariationVisibility();
 }
 
 function bindPgnFenLinks() {
     $('.fen').off('click', goToGameFen).on('click', goToGameFen);
+}
+
+function applyPgnVariationVisibility() {
+    var pgnNode = document.getElementById('pgn');
+    if (pgnNode) {
+        pgnNode.classList.toggle('pgn-variations-hidden', !pgnVariationsVisible);
+    }
+    var btn = document.getElementById('pgnVariationsToggleBtn');
+    if (btn) {
+        btn.textContent = pgnVariationsVisible ? 'HIDE' : 'SHOW';
+    }
+}
+
+function togglePgnVariations() {
+    pgnVariationsVisible = !pgnVariationsVisible;
+    applyPgnVariationVisibility();
 }
 
 // update the board position after the piece snap
@@ -3260,6 +3278,8 @@ $(function () {
         }
     });
     $('#sf18ToggleBtn').on('click', analyzePressed);
+    $('#pgnVariationsToggleBtn').on('click', togglePgnVariations);
+    applyPgnVariationVisibility();
 
     $('#analyzeMinus').on('click', multiPvDecrease);
     $('#analyzePlus').on('click', multiPvIncrease);

--- a/web/picoweb/static/js/app.js
+++ b/web/picoweb/static/js/app.js
@@ -589,7 +589,7 @@ var gameDataTable = $('#GameTable').DataTable({
 
 gameDataTable.on('select', function (e, dt, type, indexes) {
     var data = gameDataTable.rows(indexes).data().pluck('pgn')[0].split("\n");
-    loadGame(data);
+    loadGame(data, { autoExploreFinished: true });
     updateStatus();
     removeHighlights();
 });
@@ -1385,7 +1385,8 @@ function addNewMove(m, current_position, fen, props) {
     return { node: node, position: current_position };
 }
 
-function loadGame(pgn_lines) {
+function loadGame(pgn_lines, options) {
+    options = options || {};
     stopWebExploreMode(false);
     fenHash = {};
 
@@ -1569,6 +1570,10 @@ function loadGame(pgn_lines) {
     }
     setHeaders(game_headers);
     bindPgnFenLinks();
+    if (options.autoExploreFinished && isDefinitiveResult(game_headers['Result']) && fenHash['last']) {
+        currentPosition = fenHash['last'];
+        startWebExploreFromCurrentPosition();
+    }
 }
 
 function getFullGame() {

--- a/web/picoweb/static/js/app.js
+++ b/web/picoweb/static/js/app.js
@@ -639,7 +639,7 @@ function shouldAutoExploreWebClientAction() {
 }
 
 function shouldAutoExplorePgnSelection() {
-    return shouldAutoExploreWebClientAction();
+    return shouldAutoExploreWebClientAction() || shouldAutoExploreFinishedGameReview();
 }
 
 function updateWebExploreButton() {
@@ -733,6 +733,14 @@ function pgnTextHasDefinitiveResult(pgnText) {
 function shouldAutoExploreLoadedFinishedPgn() {
     var psi = window._picoSystemInfo || {};
     return Boolean(psi.loaded_pgn_finished) && !Boolean(psi.game_started);
+}
+
+function shouldAutoExploreFinishedGameReview() {
+    var psi = window._picoSystemInfo || {};
+    if (Object.prototype.hasOwnProperty.call(psi, 'game_started') && Boolean(psi.game_started)) {
+        return false;
+    }
+    return isDefinitiveResult((gameHistory && gameHistory.result) || '') || shouldAutoExploreLoadedFinishedPgn();
 }
 
 String.prototype.trim = function () {

--- a/web/picoweb/static/js/app.js
+++ b/web/picoweb/static/js/app.js
@@ -311,6 +311,8 @@ const SERVER_NAME = location.hostname
 const BOOK_SERVER_PREFIX = ''; // same origin
 const GAMES_SERVER_PREFIX = 'http://' + SERVER_NAME + ':7778';
 var pgnVariationsVisible = false;
+var webExploreMode = false;
+var webExploreGame = null;
 
 fenHash = {};
 
@@ -592,9 +594,7 @@ gameDataTable.on('select', function (e, dt, type, indexes) {
     removeHighlights();
 });
 
-// do not pick up pieces if the game is over
-// only pick up pieces for the side to move
-function createGamePointer() {
+function createPositionGamePointer() {
     var tmpGame;
 
     if (currentPosition && currentPosition.fen) {
@@ -604,6 +604,58 @@ function createGamePointer() {
         tmpGame = new Chess(setupBoardFen, chessGameType);
     }
     return tmpGame;
+}
+
+// do not pick up pieces if the game is over
+// only pick up pieces for the side to move
+function createGamePointer() {
+    if (webExploreMode && webExploreGame) {
+        return new Chess(webExploreGame.fen(), chessGameType);
+    }
+    return createPositionGamePointer();
+}
+
+function updateWebExploreButton() {
+    var btn = document.getElementById('webExploreToggleBtn');
+    if (!btn) {
+        return;
+    }
+    btn.textContent = webExploreMode ? 'ON' : 'OFF';
+    btn.classList.toggle('btn-warning', webExploreMode);
+    btn.classList.toggle('btn-primary', !webExploreMode);
+    btn.setAttribute(
+        'aria-pressed',
+        webExploreMode ? 'true' : 'false'
+    );
+}
+
+function setWebExploreMode(enabled, redraw) {
+    enabled = Boolean(enabled);
+    if (enabled) {
+        if (!webExploreMode || !webExploreGame) {
+            webExploreGame = createPositionGamePointer();
+        }
+        webExploreMode = true;
+    } else {
+        webExploreMode = false;
+        webExploreGame = null;
+    }
+    updateWebExploreButton();
+    if (redraw !== false) {
+        updateChessGround();
+        updateStatus();
+    }
+}
+
+function stopWebExploreMode(redraw) {
+    if (!webExploreMode && !webExploreGame) {
+        return;
+    }
+    setWebExploreMode(false, redraw);
+}
+
+function toggleWebExploreMode() {
+    setWebExploreMode(!webExploreMode);
 }
 
 function stripFen(fen) {
@@ -1048,6 +1100,9 @@ var updateStatus = function () {
             status += ' (check)';
         }
     }
+    if (webExploreMode) {
+        status = 'Explore: ' + status;
+    }
 
     boardStatusEl.html(status);
     if (window.analysis === true) {
@@ -1101,7 +1156,6 @@ function toColor(chess) {
 }
 
 var onSnapEnd = async function (source, target) {
-    stopAnalysis();
     var tmpGame = createGamePointer();
 
     if (!currentPosition) {
@@ -1113,7 +1167,19 @@ var onSnapEnd = async function (source, target) {
     }
 
     var move = await getMove(tmpGame, source, target);
+    if (!move) {
+        updateChessGround();
+        return;
+    }
 
+    if (webExploreMode) {
+        webExploreGame = tmpGame;
+        updateChessGround();
+        updateStatus();
+        return;
+    }
+
+    stopAnalysis();
     updateCurrentPosition(move, tmpGame);
     updateChessGround();
     $.post('/channel', {
@@ -1160,7 +1226,9 @@ function updateChessGround() {
     var turnColor = toColor(tmpGame);
     var movableColor;
 
-    if (!hasBoard) {
+    if (webExploreMode) {
+        movableColor = turnColor;
+    } else if (!hasBoard) {
         // No physical board: full diagram interactivity (NOEBOARD mode).
         movableColor = turnColor;
     } else if (psi.interaction_mode === 'remote') {
@@ -1175,7 +1243,7 @@ function updateChessGround() {
     }
 
     chessground1.set({
-        fen: currentPosition.fen,
+        fen: tmpGame.fen(),
         turnColor: turnColor,
         movable: {
             color: movableColor,
@@ -1244,6 +1312,7 @@ function addNewMove(m, current_position, fen, props) {
 }
 
 function loadGame(pgn_lines) {
+    stopWebExploreMode(false);
     fenHash = {};
 
     var curr_fen;
@@ -1482,6 +1551,7 @@ function download() {
 }
 
 function newBoard(fen) {
+    stopWebExploreMode(false);
     stopAnalysis();
 
     fenHash = {};
@@ -1554,6 +1624,7 @@ function clockShowHint() {
 }
 
 function goToPosition(fen) {
+    stopWebExploreMode(false);
     stopAnalysis();
     currentPosition = fenHash[fen];
     if (!currentPosition) {
@@ -1601,6 +1672,7 @@ window.setPicoPositionFromCurrentPgn = setPositionFromCurrentPgn;
 
 function goToStart() {
     removeHighlights();
+    stopWebExploreMode(false);
     stopAnalysis();
     currentPosition = gameHistory;
     updateChessGround();
@@ -1609,6 +1681,7 @@ function goToStart() {
 
 function goToEnd() {
     removeHighlights();
+    stopWebExploreMode(false);
     stopAnalysis();
     if (fenHash.last) {
         currentPosition = fenHash.last;
@@ -1619,6 +1692,7 @@ function goToEnd() {
 
 function goForward() {
     removeHighlights();
+    stopWebExploreMode(false);
     stopAnalysis();
     if (currentPosition && currentPosition.variations[0]) {
         currentPosition = currentPosition.variations[0];
@@ -1631,6 +1705,7 @@ function goForward() {
 
 function goBack() {
     removeHighlights();
+    stopWebExploreMode(false);
     stopAnalysis();
     if (currentPosition && currentPosition.previous) {
         currentPosition = currentPosition.previous;
@@ -1656,7 +1731,10 @@ function formatEngineOutput(line) {
     if (line.search('depth') > 0 && line.search('currmove') < 0) {
         var analysis_game = new Chess();
         var start_move_num = 1;
-        if (currentPosition && currentPosition.fen) {
+        if (webExploreMode && webExploreGame) {
+            analysis_game.load(webExploreGame.fen(), chessGameType);
+            start_move_num = getStartMoveNumFromFen(webExploreGame.fen());
+        } else if (currentPosition && currentPosition.fen) {
             analysis_game.load(currentPosition.fen, chessGameType);
             start_move_num = getCountPrevMoves(currentPosition) + 1;
         }
@@ -1755,7 +1833,9 @@ function formatEngineOutput(line) {
         if (history.length > 0) {
             var firstMoveText = '';
             var tempGame = new Chess();
-            if (currentPosition && currentPosition.fen) {
+            if (webExploreMode && webExploreGame) {
+                tempGame.load(webExploreGame.fen(), chessGameType);
+            } else if (currentPosition && currentPosition.fen) {
                 tempGame.load(currentPosition.fen, chessGameType);
             }
             var currentTurn = tempGame.turn();
@@ -2042,7 +2122,11 @@ function analyze(position_update) {
         }
     }
     var moves;
-    if (currentPosition === undefined) {
+    var startpos;
+    if (webExploreMode && webExploreGame) {
+        moves = '';
+        startpos = 'fen ' + webExploreGame.fen();
+    } else if (currentPosition === undefined) {
         moves = '';
     }
     else {
@@ -2062,19 +2146,26 @@ function analyze(position_update) {
         window.stockfish = StockfishModule;
     }
 
-    var startpos = 'startpos';
-    if (setupBoardFen !== START_FEN) {
+    if (!startpos) {
+        startpos = 'startpos';
+    }
+    if (!webExploreMode && setupBoardFen !== START_FEN) {
         startpos = 'fen ' + setupBoardFen;
     }
     if (position_update && window.stockfish) {
         window.stockfish.postMessage('stop');
     }
-    window.stockfish.postMessage('position ' + startpos + ' moves ' + moves);
+    var positionCommand = 'position ' + startpos;
+    if (moves && moves.trim()) {
+        positionCommand += ' moves ' + moves;
+    }
+    window.stockfish.postMessage(positionCommand);
     window.stockfish.postMessage('setoption name multipv value ' + window.multipv);
     window.stockfish.postMessage('go infinite');
 }
 
 function updateDGTPosition(data) {
+    stopWebExploreMode(false);
     if (data.play === 'reload') {
         // Takeback / switch-sides: always rebuild the move tree from the
         // fresh PGN so the diagram and move list are in sync, even when
@@ -2713,6 +2804,7 @@ function updateBackendAnalysis(analysis) {
 }
 
 function goToDGTFen() {
+    stopWebExploreMode(false);
     $.get('/dgt', { action: 'get_last_move' }, function (data) {
         if (data && data.fen) {
             if (data.play === 'newgame') {
@@ -3300,7 +3392,9 @@ $(function () {
     });
     $('#sf18ToggleBtn').on('click', analyzePressed);
     $('#pgnVariationsToggleBtn').on('click', togglePgnVariations);
+    $('#webExploreToggleBtn').on('click', toggleWebExploreMode);
     applyPgnVariationVisibility();
+    updateWebExploreButton();
 
     $('#analyzeMinus').on('click', multiPvDecrease);
     $('#analyzePlus').on('click', multiPvIncrease);

--- a/web/picoweb/static/js/app.js
+++ b/web/picoweb/static/js/app.js
@@ -1381,7 +1381,9 @@ function loadGame(pgn_lines) {
                 props.starting_comment = starting_comment;
                 starting_comment = '';
             }
-            lastmove = move;
+            if (variation_stack.length === 1) {
+                lastmove = move;
+            }
 
             var __ret = addNewMove({ 'move': move }, variation_stack[last_variation_stack_index], board_stack[last_board_stack_index].fen(), props);
             variation_stack[last_variation_stack_index] = __ret.node;

--- a/web/picoweb/static/js/app.js
+++ b/web/picoweb/static/js/app.js
@@ -640,12 +640,22 @@ function isPicoGameActive() {
     return Object.prototype.hasOwnProperty.call(sysInfo, 'game_started') && Boolean(sysInfo.game_started);
 }
 
+function isWebBoardMoveEntryRelevant() {
+    var sysInfo = window._picoSystemInfo || {};
+    if (!Object.prototype.hasOwnProperty.call(sysInfo, 'has_board')) {
+        return false;
+    }
+    return !sysInfo.has_board || sysInfo.interaction_mode === 'remote';
+}
+
 function updateSyncButtonAttention() {
     var btn = document.getElementById('DgtSyncBtn');
     if (!btn) {
         return;
     }
-    var needsSync = isPicoGameActive() && (webExploreMode || !isLiveMoveEntryPosition());
+    var needsSync = isPicoGameActive()
+        && isWebBoardMoveEntryRelevant()
+        && (webExploreMode || !isLiveMoveEntryPosition());
     btn.classList.toggle('sync-attention', needsSync);
     btn.title = needsSync ? 'Sync with live game' : 'Sync with DGT board';
     btn.setAttribute('aria-label', btn.title);

--- a/web/picoweb/static/js/app.js
+++ b/web/picoweb/static/js/app.js
@@ -313,6 +313,7 @@ const GAMES_SERVER_PREFIX = 'http://' + SERVER_NAME + ':7778';
 var pgnVariationsVisible = false;
 var webExploreMode = false;
 var webExploreGame = null;
+var webExploreBoardPolicyInitialized = false;
 
 fenHash = {};
 
@@ -589,7 +590,7 @@ var gameDataTable = $('#GameTable').DataTable({
 
 gameDataTable.on('select', function (e, dt, type, indexes) {
     var data = gameDataTable.rows(indexes).data().pluck('pgn')[0].split("\n");
-    loadGame(data, { autoExploreFinished: true });
+    loadGame(data);
     updateStatus();
     removeHighlights();
 });
@@ -639,7 +640,7 @@ function shouldAutoExploreWebClientAction() {
 }
 
 function shouldAutoExplorePgnSelection() {
-    return shouldAutoExploreWebClientAction() || shouldAutoExploreFinishedGameReview();
+    return shouldAutoExploreWebClientAction();
 }
 
 function updateWebExploreButton() {
@@ -690,6 +691,12 @@ function startWebExploreFromLivePosition(redraw) {
     startWebExploreFromCurrentPosition(redraw);
 }
 
+function syncWebExploreFromCurrentPosition(redraw) {
+    if (webExploreMode) {
+        startWebExploreFromCurrentPosition(redraw);
+    }
+}
+
 function startWebExploreFromGame(game, redraw) {
     webExploreGame = new Chess(game.fen(), chessGameType);
     webExploreMode = true;
@@ -708,7 +715,9 @@ function stopWebExploreMode(redraw) {
 }
 
 function resetWebExploreForPlayablePosition() {
-    stopWebExploreMode(false);
+    if (!shouldAutoExploreWebClientAction()) {
+        stopWebExploreMode(false);
+    }
 }
 
 function toggleWebExploreMode() {
@@ -726,21 +735,23 @@ function isDefinitiveResult(result) {
     return result === '1-0' || result === '0-1' || result === '1/2-1/2';
 }
 
-function pgnTextHasDefinitiveResult(pgnText) {
-    return /\b(?:1-0|0-1|1\/2-1\/2)\s*$/.test(String(pgnText || '').trim());
-}
-
 function shouldAutoExploreLoadedFinishedPgn() {
     var psi = window._picoSystemInfo || {};
     return Boolean(psi.loaded_pgn_finished) && !Boolean(psi.game_started);
 }
 
-function shouldAutoExploreFinishedGameReview() {
-    var psi = window._picoSystemInfo || {};
-    if (Object.prototype.hasOwnProperty.call(psi, 'game_started') && Boolean(psi.game_started)) {
-        return false;
+function applyInitialWebExploreBoardPolicy() {
+    if (webExploreBoardPolicyInitialized) {
+        return;
     }
-    return isDefinitiveResult((gameHistory && gameHistory.result) || '') || shouldAutoExploreLoadedFinishedPgn();
+    var psi = window._picoSystemInfo || {};
+    if (!Object.prototype.hasOwnProperty.call(psi, 'has_board')) {
+        return;
+    }
+    webExploreBoardPolicyInitialized = true;
+    if (shouldAutoExploreWebClientAction()) {
+        startWebExploreFromLivePosition(false);
+    }
 }
 
 String.prototype.trim = function () {
@@ -1402,9 +1413,7 @@ function addNewMove(m, current_position, fen, props) {
     return { node: node, position: current_position };
 }
 
-function loadGame(pgn_lines, options) {
-    options = options || {};
-    stopWebExploreMode(false);
+function loadGame(pgn_lines) {
     fenHash = {};
 
     var curr_fen;
@@ -1591,10 +1600,7 @@ function loadGame(pgn_lines, options) {
     }
     setHeaders(game_headers);
     bindPgnFenLinks();
-    if (options.autoExploreFinished && isDefinitiveResult(game_headers['Result']) && fenHash['last']) {
-        currentPosition = fenHash['last'];
-        startWebExploreFromCurrentPosition();
-    }
+    syncWebExploreFromCurrentPosition(false);
 }
 
 function getFullGame() {
@@ -1651,7 +1657,7 @@ function download() {
 }
 
 function newBoard(fen) {
-    stopWebExploreMode(false);
+    resetWebExploreForPlayablePosition();
     stopAnalysis();
 
     fenHash = {};
@@ -1665,6 +1671,7 @@ function newBoard(fen) {
     gameHistory.gameHeader = '';
     gameHistory.result = '';
     gameHistory.variations = [];
+    syncWebExploreFromCurrentPosition(false);
 
     updateChessGround();
     updateStatus();
@@ -1725,14 +1732,12 @@ function clockShowHint() {
 
 function goToPosition(fen, options) {
     options = options || {};
-    if (!options.preserveExplore) {
-        stopWebExploreMode(false);
-    }
     stopAnalysis();
     currentPosition = fenHash[fen];
     if (!currentPosition) {
         return false;
     }
+    syncWebExploreFromCurrentPosition(false);
     if (options.redraw !== false) {
         updateChessGround();
         updateStatus();
@@ -1745,7 +1750,7 @@ function goToGameFen(event) {
         event.preventDefault();
     }
     var fen = $(this).attr('data-fen');
-    var autoExplore = shouldAutoExplorePgnSelection();
+    var autoExplore = webExploreMode || shouldAutoExplorePgnSelection();
     if (goToPosition(fen, { preserveExplore: autoExplore, redraw: !autoExplore }) && autoExplore) {
         startWebExploreFromCurrentPosition();
     }
@@ -1780,19 +1785,19 @@ window.setPicoPositionFromCurrentPgn = setPositionFromCurrentPgn;
 
 function goToStart() {
     removeHighlights();
-    stopWebExploreMode(false);
     stopAnalysis();
     currentPosition = gameHistory;
+    syncWebExploreFromCurrentPosition(false);
     updateChessGround();
     updateStatus();
 }
 
 function goToEnd() {
     removeHighlights();
-    stopWebExploreMode(false);
     stopAnalysis();
     if (fenHash.last) {
         currentPosition = fenHash.last;
+        syncWebExploreFromCurrentPosition(false);
         updateChessGround();
     }
     updateStatus();
@@ -1800,11 +1805,11 @@ function goToEnd() {
 
 function goForward() {
     removeHighlights();
-    stopWebExploreMode(false);
     stopAnalysis();
     if (currentPosition && currentPosition.variations[0]) {
         currentPosition = currentPosition.variations[0];
         if (currentPosition) {
+            syncWebExploreFromCurrentPosition(false);
             updateChessGround();
         }
     }
@@ -1813,10 +1818,10 @@ function goForward() {
 
 function goBack() {
     removeHighlights();
-    stopWebExploreMode(false);
     stopAnalysis();
     if (currentPosition && currentPosition.previous) {
         currentPosition = currentPosition.previous;
+        syncWebExploreFromCurrentPosition(false);
         updateChessGround();
     }
     updateStatus();
@@ -2273,23 +2278,22 @@ function analyze(position_update) {
 }
 
 function updateDGTPosition(data) {
-    stopWebExploreMode(false);
+    var preserveExplore = webExploreMode;
     if (data.play === 'reload') {
-        var autoExploreFinished = shouldAutoExploreLoadedFinishedPgn() || pgnTextHasDefinitiveResult(data['pgn']);
         // Takeback / switch-sides: always rebuild the move tree from the
         // fresh PGN so the diagram and move list are in sync, even when
         // the target FEN already exists in the current fenHash (i.e. a
         // real move takeback where the previous position is in the list).
-        loadGame(data['pgn'].split("\n"), { autoExploreFinished: autoExploreFinished });
-        if (!goToPosition(data.fen, { preserveExplore: autoExploreFinished })) {
+        loadGame(data['pgn'].split("\n"));
+        if (!goToPosition(data.fen, { preserveExplore: preserveExplore })) {
             // Variant chess or edge-cases: force the board to the server FEN.
             forcePosition(data.fen);
         }
         return;
     }
-    if (!goToPosition(data.fen)) {
+    if (!goToPosition(data.fen, { preserveExplore: preserveExplore })) {
         loadGame(data['pgn'].split("\n"));
-        if (!goToPosition(data.fen)) {
+        if (!goToPosition(data.fen, { preserveExplore: preserveExplore })) {
             // Variant chess (e.g. atomic explosions): chess.js computed a different
             // FEN than the server sent.  Force the board to show the server's FEN.
             forcePosition(data.fen);
@@ -2506,7 +2510,7 @@ function goToHalfmove(halfmove) {
     if (!fen) {
         return false;
     }
-    var autoExplore = shouldAutoExplorePgnSelection();
+    var autoExplore = webExploreMode || shouldAutoExplorePgnSelection();
     if (!goToPosition(fen, { preserveExplore: autoExplore, redraw: !autoExplore })) {
         return false;
     }
@@ -2921,7 +2925,6 @@ function updateBackendAnalysis(analysis) {
 }
 
 function goToDGTFen() {
-    stopWebExploreMode(false);
     $.get('/dgt', { action: 'get_last_move' }, function (data) {
         if (data && data.fen) {
             if (data.play === 'newgame') {
@@ -2984,7 +2987,6 @@ function setHeaders(data) {
     if (
         !isDefinitiveResult(data.Result) &&
         isDefinitiveResult(gameHistory.result) &&
-        webExploreMode &&
         shouldAutoExploreLoadedFinishedPgn()
     ) {
         data = Object.assign({}, data, { Result: gameHistory.result });
@@ -3005,6 +3007,7 @@ function getAllInfo() {
         // when a physical board is the source of truth for piece positions.
         window._picoSystemInfo = window._picoSystemInfo || {};
         Object.assign(window._picoSystemInfo, data);
+        applyInitialWebExploreBoardPolicy();
         if (Object.prototype.hasOwnProperty.call(data, 'game_started') && window.setPicoGameActive) {
             window.setPicoGameActive(Boolean(data.game_started));
         }
@@ -3388,7 +3391,6 @@ $(function () {
                             if (window.setPicoGameActive) {
                                 window.setPicoGameActive(false);
                             }
-                            startWebExploreFromLivePosition();
                         }
                         break;
                     case 'Title':
@@ -3407,6 +3409,7 @@ $(function () {
                         window._picoSystemInfo = window._picoSystemInfo || {};
                         var _prevMode = window._picoSystemInfo.interaction_mode;
                         Object.assign(window._picoSystemInfo, data.msg);
+                        applyInitialWebExploreBoardPolicy();
                         // Clear stale clock text (e.g. engine name) the moment we
                         // enter Ponder/free-analysis mode, before the first Analysis event arrives.
                         if (isAnalysisClockMode(data.msg.interaction_mode) && !isAnalysisClockMode(_prevMode)) {

--- a/web/picoweb/static/js/app.js
+++ b/web/picoweb/static/js/app.js
@@ -726,6 +726,10 @@ function isDefinitiveResult(result) {
     return result === '1-0' || result === '0-1' || result === '1/2-1/2';
 }
 
+function pgnTextHasDefinitiveResult(pgnText) {
+    return /\b(?:1-0|0-1|1\/2-1\/2)\s*$/.test(String(pgnText || '').trim());
+}
+
 function shouldAutoExploreLoadedFinishedPgn() {
     var psi = window._picoSystemInfo || {};
     return Boolean(psi.loaded_pgn_finished) && !Boolean(psi.game_started);
@@ -2263,7 +2267,7 @@ function analyze(position_update) {
 function updateDGTPosition(data) {
     stopWebExploreMode(false);
     if (data.play === 'reload') {
-        var autoExploreFinished = shouldAutoExploreLoadedFinishedPgn();
+        var autoExploreFinished = shouldAutoExploreLoadedFinishedPgn() || pgnTextHasDefinitiveResult(data['pgn']);
         // Takeback / switch-sides: always rebuild the move tree from the
         // fresh PGN so the diagram and move list are in sync, even when
         // the target FEN already exists in the current fenHash (i.e. a
@@ -2968,6 +2972,14 @@ function setHeaders(data) {
         } else {
             chessGameType = 0;
         }
+    }
+    if (
+        !isDefinitiveResult(data.Result) &&
+        isDefinitiveResult(gameHistory.result) &&
+        webExploreMode &&
+        shouldAutoExploreLoadedFinishedPgn()
+    ) {
+        data = Object.assign({}, data, { Result: gameHistory.result });
     }
     gameHistory.gameHeader = getWebGameHeader(data);
     gameHistory.result = data.Result;

--- a/web/picoweb/static/js/app.js
+++ b/web/picoweb/static/js/app.js
@@ -2576,10 +2576,17 @@ function updateTutorMistakes(mistakes) {
         var figUser = figurinizeMove(item.user_move) || (item.user_move || '');
         var figBest = figurinizeMove(item.best_move) || (item.best_move || '');
         var moveText = (item.move_no ? item.move_no + ' ' : '') + figUser + nag;
-        entry.innerHTML = moveText + ' \u2014 ' + formatTutorMistakeImpact(item) + ', best: ' + figBest;
+        if (item.reason === 'variation') {
+            entry.innerHTML = moveText + ' \u2014 has sideline';
+        } else {
+            entry.innerHTML = moveText + ' \u2014 ' + formatTutorMistakeImpact(item) + ', best: ' + figBest;
+        }
         if (item.halfmove) {
             var mistakeHalfmove = parseInt(item.halfmove, 10);
-            var targetHalfmove = mistakeHalfmove > 2 ? mistakeHalfmove - 1 : mistakeHalfmove;
+            var explicitTargetHalfmove = parseInt(item.target_halfmove, 10);
+            var targetHalfmove = !Number.isNaN(explicitTargetHalfmove)
+                ? explicitTargetHalfmove
+                : (mistakeHalfmove > 2 ? mistakeHalfmove - 1 : mistakeHalfmove);
             entry.dataset.halfmove = targetHalfmove;
             entry.addEventListener('click', function () {
                 goToHalfmove(entry.dataset.halfmove);

--- a/web/picoweb/static/js/app.js
+++ b/web/picoweb/static/js/app.js
@@ -2510,6 +2510,22 @@ function updateBackendAnalysisLine(analysis) {
 
 var analysisDisplayVisible = false;
 var lastServerAnalysis = null;
+var lastServerAnalysisKey = null;
+
+function backendAnalysisKey(analysis) {
+    if (!analysis) {
+        return '';
+    }
+    return JSON.stringify({
+        source: analysis.source || '',
+        depth: analysis.depth,
+        score: analysis.score,
+        mate: analysis.mate,
+        fen: analysis.fen || '',
+        pv: Array.isArray(analysis.pv) ? analysis.pv : [],
+        suppress_engine_line: !!analysis.suppress_engine_line
+    });
+}
 
 // Ponder mode: real-time single-line display in #DGTClockText
 // Format: "24. Qxe5+ d27 +2.34"  (all on one line, updated on every Analysis event)
@@ -2669,6 +2685,7 @@ function setSF18Placeholder() {
 function updateBackendAnalysis(analysis) {
     if (!analysis) {
         lastServerAnalysis = null;
+        lastServerAnalysisKey = null;
         updateBackendAnalysisSourceBadge('engine');
         // Clear content but keep button state
         var metaEl = document.getElementById('engineMeta');
@@ -2679,13 +2696,17 @@ function updateBackendAnalysis(analysis) {
     }
     // Upstream: explicit clear signal resets the engine line to placeholder state.
     if (analysis.clear) {
+        lastServerAnalysisKey = null;
         updateBackendAnalysisSourceBadge(analysis.source);
         setEngineLinePlaceholder();
         return;
     }
+    var analysisKey = backendAnalysisKey(analysis);
+    var unchanged = analysisKey === lastServerAnalysisKey;
     lastServerAnalysis = analysis;
+    lastServerAnalysisKey = analysisKey;
     updateBackendAnalysisSourceBadge(analysis.source);
-    if (!analysisDisplayVisible) {
+    if (!analysisDisplayVisible || unchanged) {
         return;
     }
     updateBackendAnalysisLine(analysis);

--- a/web/picoweb/static/js/app.js
+++ b/web/picoweb/static/js/app.js
@@ -644,7 +644,9 @@ function shouldAutoExploreWebClientAction() {
 }
 
 function shouldAutoExplorePgnSelection() {
-    return shouldAutoExploreWebClientAction();
+    // PGN navigation is review-only. Keep Explore explicit so browser-side
+    // moves and Web Stockfish analysis cannot start from a move-list click.
+    return false;
 }
 
 function updateWebExploreButton() {

--- a/web/picoweb/static/js/app.js
+++ b/web/picoweb/static/js/app.js
@@ -3340,6 +3340,9 @@ $(function () {
                         pickPromotion(null) // reset promotion dialog if still showing
                         clearBrainHint();
                         updateDGTPosition(data);
+                        if (hasDefinitiveGameResult() && window.setPicoGameActive) {
+                            window.setPicoGameActive(false);
+                        }
                         updateTutorMistakes(data.mistakes);
                         updateCheckCounters(data.variant, data.checks);
                         if (data.play === 'reload') {

--- a/web/picoweb/static/js/app.js
+++ b/web/picoweb/static/js/app.js
@@ -314,6 +314,7 @@ var pgnVariationsVisible = false;
 var webExploreMode = false;
 var webExploreGame = null;
 var webExploreBoardPolicyInitialized = false;
+var livePgnTreeActive = true;
 var webAnalysisSearchActive = false;
 var webAnalysisStopRequested = false;
 var webAnalysisStopReasserted = false;
@@ -594,7 +595,7 @@ var gameDataTable = $('#GameTable').DataTable({
 
 gameDataTable.on('select', function (e, dt, type, indexes) {
     var data = gameDataTable.rows(indexes).data().pluck('pgn')[0].split("\n");
-    loadGame(data);
+    loadGame(data, { livePgnTree: false });
     updateStatus();
     removeHighlights();
 });
@@ -630,6 +631,26 @@ function isCurrentPicoLivePosition() {
     return currentPosition === fenHash.last || currentPosition.fen === fenHash.last.fen;
 }
 
+function isLiveMoveEntryPosition() {
+    return livePgnTreeActive && isCurrentPicoLivePosition();
+}
+
+function updateSyncButtonAttention() {
+    var btn = document.getElementById('DgtSyncBtn');
+    if (!btn) {
+        return;
+    }
+    var needsSync = webExploreMode || !isLiveMoveEntryPosition();
+    btn.classList.toggle('sync-attention', needsSync);
+    btn.title = needsSync ? 'Sync with live game' : 'Sync with DGT board';
+    btn.setAttribute('aria-label', btn.title);
+}
+
+function setLivePgnTreeActive(active) {
+    livePgnTreeActive = Boolean(active);
+    updateSyncButtonAttention();
+}
+
 function syncToCurrentPicoLivePosition() {
     if (fenHash && fenHash.last) {
         currentPosition = fenHash.last;
@@ -645,7 +666,7 @@ function shouldAutoExploreWebClientAction() {
 
 function canSubmitWebBoardMove(movingColor) {
     var psi = window._picoSystemInfo || {};
-    if (!isCurrentPicoLivePosition() || !Object.prototype.hasOwnProperty.call(psi, 'has_board')) {
+    if (!isLiveMoveEntryPosition() || !Object.prototype.hasOwnProperty.call(psi, 'has_board')) {
         return false;
     }
     if (!psi.has_board) {
@@ -676,6 +697,7 @@ function updateWebExploreButton() {
         'aria-pressed',
         webExploreMode ? 'true' : 'false'
     );
+    updateSyncButtonAttention();
 }
 
 function setWebExploreMode(enabled, redraw) {
@@ -1178,6 +1200,7 @@ function updateCurrentPosition(move, tmpGame) {
 var updateStatus = function () {
     var status = '';
     bindPgnFenLinks();
+    updateSyncButtonAttention();
 
     var moveColor = 'White';
     var tmpGame = createGamePointer();
@@ -1435,7 +1458,9 @@ function addNewMove(m, current_position, fen, props) {
     return { node: node, position: current_position };
 }
 
-function loadGame(pgn_lines) {
+function loadGame(pgn_lines, options) {
+    options = options || {};
+    setLivePgnTreeActive(options.livePgnTree !== false);
     fenHash = {};
 
     var curr_fen;
@@ -1679,6 +1704,7 @@ function download() {
 }
 
 function newBoard(fen) {
+    setLivePgnTreeActive(true);
     resetWebExploreForPlayablePosition();
     stopAnalysis();
 
@@ -2359,6 +2385,7 @@ function analyze(position_update) {
 }
 
 function updateDGTPosition(data) {
+    setLivePgnTreeActive(true);
     var preserveExplore = webExploreMode;
     if (data.play === 'reload') {
         // Takeback / switch-sides: always rebuild the move tree from the

--- a/web/picoweb/static/js/app.js
+++ b/web/picoweb/static/js/app.js
@@ -726,6 +726,11 @@ function isDefinitiveResult(result) {
     return result === '1-0' || result === '0-1' || result === '1/2-1/2';
 }
 
+function shouldAutoExploreLoadedFinishedPgn() {
+    var psi = window._picoSystemInfo || {};
+    return Boolean(psi.loaded_pgn_finished) && !Boolean(psi.game_started);
+}
+
 String.prototype.trim = function () {
     return this.replace(/\s*$/g, '');
 };
@@ -1449,6 +1454,7 @@ function loadGame(pgn_lines, options) {
 
     var in_variation = false;
     var starting_comment = '';
+    var game_result_token;
 
     var result;
     var lastmove;
@@ -1458,7 +1464,7 @@ function loadGame(pgn_lines, options) {
         var comment;
 
         if (token === '1-0' || token === '0-1' || token === '1/2-1/2' || token === '*') {
-            game_headers['Result'] = token;
+            game_result_token = token;
         }
         else if (token[0] === '{') {
             last_variation_stack_index = variation_stack.length - 1;
@@ -1555,6 +1561,9 @@ function loadGame(pgn_lines, options) {
             var __ret = addNewMove({ 'move': move }, variation_stack[last_variation_stack_index], board_stack[last_board_stack_index].fen(), props);
             variation_stack[last_variation_stack_index] = __ret.node;
         }
+    }
+    if (isDefinitiveResult(game_result_token) || !isDefinitiveResult(game_headers['Result'])) {
+        game_headers['Result'] = game_result_token || game_headers['Result'] || '*';
     }
     if (lastmove && (computerside == "" || (computerside != "" && lastmove.color != computerside))) {
         var tmp_board = new Chess(currentPosition.fen, chessGameType);
@@ -2254,12 +2263,13 @@ function analyze(position_update) {
 function updateDGTPosition(data) {
     stopWebExploreMode(false);
     if (data.play === 'reload') {
+        var autoExploreFinished = shouldAutoExploreLoadedFinishedPgn();
         // Takeback / switch-sides: always rebuild the move tree from the
         // fresh PGN so the diagram and move list are in sync, even when
         // the target FEN already exists in the current fenHash (i.e. a
         // real move takeback where the previous position is in the list).
-        loadGame(data['pgn'].split("\n"));
-        if (!goToPosition(data.fen)) {
+        loadGame(data['pgn'].split("\n"), { autoExploreFinished: autoExploreFinished });
+        if (!goToPosition(data.fen, { preserveExplore: autoExploreFinished })) {
             // Variant chess or edge-cases: force the board to the server FEN.
             forcePosition(data.fen);
         }

--- a/web/picoweb/templates/clock.html
+++ b/web/picoweb/templates/clock.html
@@ -1318,6 +1318,8 @@
                     btn.addEventListener('click', function() {
                         if (def.key === 'handbrain') {
                             navigateTo(showModeHandBrainGrid);
+                        } else if (def.key === 'pgnreplay') {
+                            navigateTo(showModePgnReplayGrid);
                         } else {
                             handleSubpanelAction(def.action, null);
                         }
@@ -1360,12 +1362,47 @@
                 subContent.appendChild(grid);
             }
 
+            function showModePgnReplayGrid() {
+                setOverlayPath('Mode > PGN Replay');
+                var mainGrid = document.getElementById('ovl-mode-tile-grid');
+                var subPanel = document.getElementById('ovl-mode-pgnreplay-panel');
+                var subContent = document.getElementById('ovl-mode-pgnreplay-content');
+                if (!subPanel) return;
+                mainGrid.style.display = 'none';
+                subPanel.style.display = '';
+                subContent.innerHTML = '';
+
+                var grid = document.createElement('div');
+                grid.className = 'pico-sub-tile-grid';
+                [
+                    ['📖 Replay', 'mode-pgnreplay-fast'],
+                    ['🧭 Replay + Tutor Lines', 'mode-pgnreplay-tutor']
+                ].forEach(function(p) {
+                    var btn = document.createElement('button');
+                    btn.className = 'pico-sub-tile';
+                    var lEl = document.createElement('span'); lEl.className = 'pico-sub-tile-label';
+                    lEl.textContent = p[0];
+                    btn.appendChild(lEl);
+                    btn.addEventListener('click', function() {
+                        handleSubpanelAction(p[1], btn);
+                    });
+                    grid.appendChild(btn);
+                });
+                for (var _pr = 0; _pr < 7; _pr++) {
+                    var _pe = document.createElement('button'); _pe.className = 'pico-sub-tile pico-empty-tile';
+                    _pe.setAttribute('aria-hidden','true'); _pe.tabIndex = -1; grid.appendChild(_pe);
+                }
+                subContent.appendChild(grid);
+            }
+
             function showMode() {
                 showSubpanel('overlay-mode');
                 var mg = document.getElementById('ovl-mode-tile-grid');
                 var sp = document.getElementById('ovl-mode-hb-panel');
+                var rp = document.getElementById('ovl-mode-pgnreplay-panel');
                 if (mg) mg.style.display = '';
                 if (sp) sp.style.display = 'none';
+                if (rp) rp.style.display = 'none';
                 renderModeTiles();
             }
             function showTime() {
@@ -3283,15 +3320,27 @@
                     case 'mode-remote':
                     case 'mode-ponder':
                     case 'mode-pgnreplay':
+                    case 'mode-pgnreplay-fast':
+                    case 'mode-pgnreplay-tutor':
                         var modeSub = document.getElementById('ovl-mode-sub');
-                        if (modeSub) modeSub.textContent = modeLabel(action.replace('mode-', ''));
+                        var selectedMode = action.replace('mode-', '');
+                        var modeNameForPost = selectedMode;
+                        var tutorLinesQuery = '';
+                        if (selectedMode === 'pgnreplay-fast') {
+                            modeNameForPost = 'pgnreplay';
+                            tutorLinesQuery = '&tutor_lines=false';
+                        } else if (selectedMode === 'pgnreplay-tutor') {
+                            modeNameForPost = 'pgnreplay';
+                            tutorLinesQuery = '&tutor_lines=true';
+                        }
+                        if (modeSub) modeSub.textContent = modeLabel(modeNameForPost);
                         var tutorSettings = normalizeTutorSettings(window._picoTutorSettings);
                         var clearHandBrainCoach = tutorSettings.tutor_coach === 'brain' || tutorSettings.tutor_coach === 'hand';
                         if (clearHandBrainCoach) {
                             tutorSettings.tutor_coach = 'on';
                             setTutorSettingsOptimistic(tutorSettings);
                         }
-                        post('action=set_mode&mode=' + action.replace('mode-', '')).finally(function() {
+                        post('action=set_mode&mode=' + modeNameForPost + tutorLinesQuery).finally(function() {
                             if (clearHandBrainCoach) post('action=picotutor&tutor=coach&val=on');
                         });
                         close(); break;
@@ -3418,6 +3467,10 @@
                 // Local back buttons are kept in the markup for compatibility, but
                 // all back navigation now goes through the header stack.
                 if (e.target.closest('#ovl-mode-hb-back')) {
+                    goBack();
+                    return;
+                }
+                if (e.target.closest('#ovl-mode-pgnreplay-back')) {
                     goBack();
                     return;
                 }
@@ -3938,6 +3991,11 @@
                     <button class="pico-col-back" id="ovl-mode-hb-back">‹ Back</button>
                     <div class="pico-sub-grid-label">Hand &amp; Brain — choose role</div>
                     <div id="ovl-mode-hb-content"></div>
+                </div>
+                <div id="ovl-mode-pgnreplay-panel" style="display:none; flex-direction:column; flex:1;">
+                    <button class="pico-col-back" id="ovl-mode-pgnreplay-back">‹ Back</button>
+                    <div class="pico-sub-grid-label">PGN Replay — choose replay type</div>
+                    <div id="ovl-mode-pgnreplay-content"></div>
                 </div>
             </div><!-- #overlay-mode -->
 

--- a/web/picoweb/templates/clock.html
+++ b/web/picoweb/templates/clock.html
@@ -732,6 +732,10 @@
                                                         <button id="engineToggleBtn" class="btn btn-sm btn-primary analysis-toolbar-btn">SHOW</button>
                                                     </span>
                                                     <span class="analysis-control-set">
+                                                        <span class="analysis-control-label">Lines</span>
+                                                        <button id="pgnVariationsToggleBtn" class="btn btn-sm btn-primary analysis-toolbar-btn">SHOW</button>
+                                                    </span>
+                                                    <span class="analysis-control-set">
                                                         <span class="analysis-control-label">Web</span>
                                                         <span class="btn-group btn-group-xs" id="sf18PmGroup" style="display:none">
                                                             <button id="analyzeMinus" class="btn btn-sm btn-primary book-switch-btn" aria-label="Fewer lines">

--- a/web/picoweb/templates/clock.html
+++ b/web/picoweb/templates/clock.html
@@ -747,6 +747,10 @@
                                                         </span>
                                                         <button id="sf18ToggleBtn" class="btn btn-sm btn-primary analysis-toolbar-btn">SHOW</button>
                                                     </span>
+                                                    <span class="analysis-control-set">
+                                                        <span class="analysis-control-label">Explore</span>
+                                                        <button id="webExploreToggleBtn" class="btn btn-sm btn-primary analysis-toolbar-btn" title="Temporarily explore moves on the web board">OFF</button>
+                                                    </span>
                                                 </div>
 
                                                 <!-- Server engine analysis (static structure, JS updates content) -->

--- a/web/picoweb/templates/clock.html
+++ b/web/picoweb/templates/clock.html
@@ -2476,7 +2476,7 @@
 
             var GAME_OPT = {
                 'save':    { label: 'Save to Slot', items: [['Slot 1','save_game&slot=1'],['Slot 2','save_game&slot=2'],['Slot 3','save_game&slot=3']] },
-                'read':    { label: 'Load from Slot', items: [['Last Game','load_game&slot=0'],['Slot 1','load_game&slot=1'],['Slot 2','load_game&slot=2'],['Slot 3','load_game&slot=3']] },
+                'read':    { label: 'Load from Slot', items: [['Last Game','load_game&slot=0'],['Last Replay','load_game&slot=4'],['Slot 1','load_game&slot=1'],['Slot 2','load_game&slot=2'],['Slot 3','load_game&slot=3']] },
                 'end':     { label: 'Set Result', items: [['White wins','game_end&result=white'],['Black wins','game_end&result=black'],['Draw','game_end&result=draw']] }
             };
             function showGameOpts(action) {

--- a/web/picoweb/templates/clock.html
+++ b/web/picoweb/templates/clock.html
@@ -724,9 +724,6 @@
                                                 <div id="engineStatus"></div>
 
                                                 <div class="analysis-toolbar" aria-label="Analysis controls">
-                                                    <button type="button" id="tutorWatchBtn" class="btn btn-sm btn-outline-primary analysis-toolbar-btn" title="Toggle Tutor analysis/watch" aria-label="Toggle Tutor analysis/watch">
-                                                        <i class="fa fa-eye-slash" aria-hidden="true"></i><span>T</span>
-                                                    </button>
                                                     <span class="analysis-control-set">
                                                         <span class="analysis-control-label">Pico</span>
                                                         <button id="engineToggleBtn" class="btn btn-sm btn-primary analysis-toolbar-btn">SHOW</button>
@@ -959,45 +956,6 @@
                             } catch (error) {
                                 console.error('Error starting new game:', error);
                             }
-                        }
-                    });
-                }
-
-                // Tutor+Watch combined button event handler
-                const tutorWatchBtn = document.getElementById('tutorWatchBtn');
-                if (tutorWatchBtn) {
-                    let tutorWatchActive = Boolean(window.picoWebConfig && window.picoWebConfig.tutorWatchActive);
-                    const tutorWatchSpan = tutorWatchBtn.querySelector('span');
-                    const tutorWatchIcon = tutorWatchBtn.querySelector('i');
-
-                    function setTutorWatchState(active) {
-                        tutorWatchActive = Boolean(active);
-                        if (tutorWatchActive) {
-                            tutorWatchBtn.classList.add('active');
-                            tutorWatchSpan.innerHTML = 'T';
-                            tutorWatchIcon.className = 'fa fa-eye';
-                        } else {
-                            tutorWatchBtn.classList.remove('active');
-                            tutorWatchSpan.innerHTML = 'T';
-                            tutorWatchIcon.className = 'fa fa-eye-slash';
-                        }
-                    }
-
-                    window.setTutorWatchState = setTutorWatchState;
-                    setTutorWatchState(tutorWatchActive);
-
-                    tutorWatchBtn.addEventListener('click', async function () {
-                        try {
-                            const nextActive = !tutorWatchActive;
-                            // Enviar acción combinada al servidor
-                            await fetch('/channel', {
-                                method: 'POST',
-                                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-                                body: `action=tutor_watch&active=${nextActive}`
-                            });
-                            setTutorWatchState(nextActive);
-                        } catch (error) {
-                            console.error('Error toggling tutor+watch:', error);
                         }
                     });
                 }


### PR DESCRIPTION
## Summary

This PR adds experimental support for preserving and displaying PicoTutor side-line variations in PGN data, and decouples PGN loading from PGN Replay mode.

## Changes

- Store up to 3 PicoTutor evaluation PVs that are better than the played move.
- Materialize stored tutor PVs as PGN node variations when saving/exporting PGN.
- Send PGN variations to the web client and keep the web move list usable with side lines.
- Fix PGN move-list click handling after PGN re-rendering.
- Change normal PGN load behavior:
  - Loaded games are shown immediately in their current/final state.
  - Loading a game no longer automatically starts PGN Replay.
  - Completed loaded games are reviewable but not marked as active games.
- Change explicit PGN Replay behavior:
  - Replays the already-loaded PGN object when available.
  - Falls back to `last_game.pgn` only when no PGN is loaded.
  - Does not overwrite `last_game.pgn`; replay output remains separate.
- Add `pgn_replay_tutor_regeneration` behavior:
  - If loaded PGN already contains variations, tutor regeneration is disabled during replay.
  - Replay no longer waits for tutor depth when regeneration is disabled.
  - Tutor remains active for normal live play.
- Add PGN variation detection helper and tests.

## Manual Testing

Tested on the feature branch with noeboard/web client:

- Played new tutor-active games and confirmed tutor side-line variations are generated.
- Confirmed saved `games/last_game.pgn` contains variations.
- Loaded a saved game with variations and confirmed:
  - full PGN appears immediately,
  - PGN side lines are visible,
  - PGN move-list positions can be clicked immediately,
  - completed game is shown as no active game.
- Switched explicitly to PGN Replay after loading:
  - replay used the already-loaded PGN,
  - replay advanced quickly without waiting for tutor depth when existing variations were present,
  - no crash observed.
- Confirmed uploading PGN uses the normal load path, not automatic PGN Replay.

## Automated Testing

```text
venv/bin/python -m unittest tests.test_pgn tests.test_picotutor tests.test_server
venv/bin/tox -e unit