### PR TITLE
425 engine list improvement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -476,6 +476,22 @@ the same code path.
 - The `best_sent_depth` optimization must be reset on engine switch so the new
   engine can send fresh depth updates immediately.
 
+## Engine Manufacturer Menus
+
+- Parse strict `; Manufacturer: <name>` directives in every engine INI, not
+  only `retro.ini`. This also applies to future engine catalogs read through
+  the common INI loader.
+- Manufacturer grouping is decided independently for each catalog. If no
+  engine in a catalog has manufacturer metadata, preserve the original flat
+  engine list.
+- If at least one engine in a catalog has manufacturer metadata, group entries
+  without metadata under `Other`.
+- Presentation sorting and grouping must retain stable indexes into the
+  original engine catalogs; engine selection and persisted paths depend on
+  those indexes.
+- Keep the web menu and DGT/clock menu behavior aligned for Modern, Retro, and
+  Special/Favorites catalogs.
+
 ## Tutor Behavior Outside PONDER
 
 - Non-`PONDER` modes keep their existing tutor behavior.

--- a/configuration.py
+++ b/configuration.py
@@ -34,6 +34,12 @@ class Configuration:
         )
         self.parser.add_argument("-el", "--engine-level", type=str, help="UCI engine level", default=None)
         self.parser.add_argument(
+            "--engine-menu-sort",
+            choices=["file", "engine", "manufacturer"],
+            default="file",
+            help="Retro engine menu order: file, engine name, or manufacturer",
+        )
+        self.parser.add_argument(
             "-er",
             "--engine-remote",
             type=str,

--- a/dgt/menu.py
+++ b/dgt/menu.py
@@ -753,9 +753,12 @@ class DgtMenu(object):
     def _step_retro_engine_in_group(self, step: int):
         groups = EngineProvider.get_retro_groups()
         if not groups:
-            self.menu_retro_engine_index = (self.menu_retro_engine_index + step) % len(
-                EngineProvider.retro_engines
-            )
+            indexes = EngineProvider.get_flat_retro_engine_indexes()
+            try:
+                current_position = indexes.index(self.menu_retro_engine_index)
+            except ValueError:
+                current_position = 0
+            self.menu_retro_engine_index = indexes[(current_position + step) % len(indexes)]
             return
         group = groups[self.menu_retro_manufacturer_index]
         indexes = group["engine_indexes"]

--- a/dgt/menu.py
+++ b/dgt/menu.py
@@ -130,6 +130,7 @@ class MenuState(object):
     ENG_MODERN_NAME_LEVEL = 611000
 
     ENG_RETRO = 630000
+    ENG_RETRO_MANUFACTURER = 630500
     ENG_RETRO_NAME = 631000
     ENG_RETRO_NAME_LEVEL = 631100
 
@@ -348,6 +349,8 @@ class DgtMenu(object):
         self.menu_modern_engine_level = 0
         self.menu_retro_engine_index = 0  # index of the currently selected engine within installed retro engines
         self.menu_retro_engine_level = 0
+        self.menu_retro_manufacturer_index = 0
+        self.menu_retro_group_engine_index = 0
         self.menu_fav_engine_index = 0  # index of the currently selected engine within installed fav engines
         self.menu_fav_engine_level = 0
         self.menu_engine = EngineTop.MODERN_ENGINE
@@ -696,8 +699,13 @@ class DgtMenu(object):
                 break
         for index, eng in enumerate(EngineProvider.retro_engines):
             if current_engine["file"] == eng["file"]:
-                self.state = MenuState.ENG_RETRO_NAME
                 self.menu_retro_engine_index = index
+                self._sync_retro_group_selection()
+                self.state = (
+                    MenuState.ENG_RETRO_MANUFACTURER
+                    if EngineProvider.get_retro_groups()
+                    else MenuState.ENG_RETRO_NAME
+                )
                 self.menu_engine = EngineTop.RETRO_ENGINE
                 is_retro_engine = True
                 break
@@ -709,6 +717,50 @@ class DgtMenu(object):
                     self.menu_engine = EngineTop.FAV_ENGINE
                 break
         self.menu_top = Top.ENGINE
+
+    def set_engine_menu_sort(self, sort_order: str) -> str:
+        """Apply a live presentation-order change while retaining the retro engine index."""
+        selected_sort = EngineProvider.set_engine_menu_sort(sort_order)
+        self._sync_retro_group_selection()
+        return selected_sort
+
+    def _sync_retro_group_selection(self):
+        groups = EngineProvider.get_retro_groups()
+        if not groups:
+            self.menu_retro_manufacturer_index = 0
+            self.menu_retro_group_engine_index = 0
+            return
+        for group_index, group in enumerate(groups):
+            try:
+                engine_index = group["engine_indexes"].index(self.menu_retro_engine_index)
+            except ValueError:
+                continue
+            self.menu_retro_manufacturer_index = group_index
+            self.menu_retro_group_engine_index = engine_index
+            return
+        self.menu_retro_manufacturer_index = 0
+        self.menu_retro_group_engine_index = 0
+        self.menu_retro_engine_index = groups[0]["engine_indexes"][0]
+
+    def _select_first_engine_in_retro_group(self):
+        groups = EngineProvider.get_retro_groups()
+        if not groups:
+            return
+        self.menu_retro_manufacturer_index %= len(groups)
+        self.menu_retro_group_engine_index = 0
+        self.menu_retro_engine_index = groups[self.menu_retro_manufacturer_index]["engine_indexes"][0]
+
+    def _step_retro_engine_in_group(self, step: int):
+        groups = EngineProvider.get_retro_groups()
+        if not groups:
+            self.menu_retro_engine_index = (self.menu_retro_engine_index + step) % len(
+                EngineProvider.retro_engines
+            )
+            return
+        group = groups[self.menu_retro_manufacturer_index]
+        indexes = group["engine_indexes"]
+        self.menu_retro_group_engine_index = (self.menu_retro_group_engine_index + step) % len(indexes)
+        self.menu_retro_engine_index = indexes[self.menu_retro_group_engine_index]
 
     def inside_updt_menu(self):
         """Inside update menu."""
@@ -1481,6 +1533,26 @@ class DgtMenu(object):
         text = self.dgttranslate.text(EngineTop.RETRO_ENGINE.value)
         return text
 
+    def _get_current_retro_manufacturer_name(self):
+        groups = EngineProvider.get_retro_groups()
+        manufacturer = groups[self.menu_retro_manufacturer_index]["manufacturer"]
+        return Dgt.DISPLAY_TEXT(
+            web_text=manufacturer,
+            large_text=manufacturer[:11],
+            medium_text=manufacturer[:8],
+            small_text=manufacturer[:6],
+            wait=True,
+            beep=self.dgttranslate.bl(BeepLevel.BUTTON),
+            maxtime=0,
+            devs={"ser", "i2c", "web"},
+        )
+
+    def enter_eng_retro_manufacturer_menu(self):
+        """Enter the optional manufacturer level of the Retro menu."""
+        self.state = MenuState.ENG_RETRO_MANUFACTURER
+        self._sync_retro_group_selection()
+        return self._get_current_retro_manufacturer_name()
+
     def enter_fav_eng_menu(self):
         """Set the menu state."""
         self.state = MenuState.ENG_FAV
@@ -2058,8 +2130,14 @@ class DgtMenu(object):
         elif self.state == MenuState.ENG_RETRO:
             text = self.enter_engine_menu()
 
-        elif self.state == MenuState.ENG_RETRO_NAME:
+        elif self.state == MenuState.ENG_RETRO_MANUFACTURER:
             text = self.enter_retro_eng_menu()
+
+        elif self.state == MenuState.ENG_RETRO_NAME:
+            if EngineProvider.get_retro_groups():
+                text = self.enter_eng_retro_manufacturer_menu()
+            else:
+                text = self.enter_retro_eng_menu()
 
         elif self.state == MenuState.ENG_RETRO_NAME_LEVEL:
             text = self.enter_eng_retro_name_menu()
@@ -2843,6 +2921,13 @@ class DgtMenu(object):
             self.res_engine_level = self.menu_modern_engine_level
 
         elif self.state == MenuState.ENG_RETRO:
+            if EngineProvider.get_retro_groups():
+                text = self.enter_eng_retro_manufacturer_menu()
+            else:
+                text = self.enter_eng_retro_name_menu()
+
+        elif self.state == MenuState.ENG_RETRO_MANUFACTURER:
+            self._select_first_engine_in_retro_group()
             text = self.enter_eng_retro_name_menu()
 
         elif self.state == MenuState.ENG_RETRO_NAME:
@@ -3768,8 +3853,14 @@ class DgtMenu(object):
             self.menu_engine = EngineTopLoop.prev(self.menu_engine)
             text = self.dgttranslate.text(self.menu_engine.value)
 
+        elif self.state == MenuState.ENG_RETRO_MANUFACTURER:
+            groups = EngineProvider.get_retro_groups()
+            self.menu_retro_manufacturer_index = (self.menu_retro_manufacturer_index - 1) % len(groups)
+            self._select_first_engine_in_retro_group()
+            text = self._get_current_retro_manufacturer_name()
+
         elif self.state == MenuState.ENG_RETRO_NAME:
-            self.menu_retro_engine_index = (self.menu_retro_engine_index - 1) % len(EngineProvider.retro_engines)
+            self._step_retro_engine_in_group(-1)
             text = self._get_current_retro_engine_name()
 
         elif self.state == MenuState.ENG_RETRO_NAME_LEVEL:
@@ -4454,8 +4545,14 @@ class DgtMenu(object):
             self.menu_engine = EngineTopLoop.next(self.menu_engine)
             text = self.dgttranslate.text(self.menu_engine.value)
 
+        elif self.state == MenuState.ENG_RETRO_MANUFACTURER:
+            groups = EngineProvider.get_retro_groups()
+            self.menu_retro_manufacturer_index = (self.menu_retro_manufacturer_index + 1) % len(groups)
+            self._select_first_engine_in_retro_group()
+            text = self._get_current_retro_manufacturer_name()
+
         elif self.state == MenuState.ENG_RETRO_NAME:
-            self.menu_retro_engine_index = (self.menu_retro_engine_index + 1) % len(EngineProvider.retro_engines)
+            self._step_retro_engine_in_group(1)
             text = self._get_current_retro_engine_name()
 
         elif self.state == MenuState.ENG_RETRO_NAME_LEVEL:

--- a/dgt/menu.py
+++ b/dgt/menu.py
@@ -126,6 +126,7 @@ class MenuState(object):
     ENGINE = 550000
 
     ENG_MODERN = 600000
+    ENG_MODERN_MANUFACTURER = 600500
     ENG_MODERN_NAME = 610000
     ENG_MODERN_NAME_LEVEL = 611000
 
@@ -135,6 +136,7 @@ class MenuState(object):
     ENG_RETRO_NAME_LEVEL = 631100
 
     ENG_FAV = 650000
+    ENG_FAV_MANUFACTURER = 650500
     ENG_FAV_NAME = 651000
     ENG_FAV_NAME_LEVEL = 651100
 
@@ -347,12 +349,16 @@ class DgtMenu(object):
         self.menu_engine_level = 0
         self.menu_modern_engine_index = 0  # index of the currently selected engine within installed modern engines
         self.menu_modern_engine_level = 0
+        self.menu_modern_manufacturer_index = 0
+        self.menu_modern_group_engine_index = 0
         self.menu_retro_engine_index = 0  # index of the currently selected engine within installed retro engines
         self.menu_retro_engine_level = 0
         self.menu_retro_manufacturer_index = 0
         self.menu_retro_group_engine_index = 0
         self.menu_fav_engine_index = 0  # index of the currently selected engine within installed fav engines
         self.menu_fav_engine_level = 0
+        self.menu_fav_manufacturer_index = 0
+        self.menu_fav_group_engine_index = 0
         self.menu_engine = EngineTop.MODERN_ENGINE
 
         self.menu_book = 0
@@ -692,15 +698,20 @@ class DgtMenu(object):
         is_retro_engine = False
         for index, eng in enumerate(EngineProvider.modern_engines):
             if current_engine["file"] == eng["file"]:
-                self.state = MenuState.ENG_MODERN_NAME
                 self.menu_modern_engine_index = index
+                self._sync_engine_group_selection("modern")
+                self.state = (
+                    MenuState.ENG_MODERN_MANUFACTURER
+                    if EngineProvider.get_engine_groups(EngineProvider.modern_engines)
+                    else MenuState.ENG_MODERN_NAME
+                )
                 self.menu_engine = EngineTop.MODERN_ENGINE
                 is_modern_engine = True
                 break
         for index, eng in enumerate(EngineProvider.retro_engines):
             if current_engine["file"] == eng["file"]:
                 self.menu_retro_engine_index = index
-                self._sync_retro_group_selection()
+                self._sync_engine_group_selection("retro")
                 self.state = (
                     MenuState.ENG_RETRO_MANUFACTURER
                     if EngineProvider.get_retro_groups()
@@ -713,57 +724,108 @@ class DgtMenu(object):
             if current_engine["file"] == eng["file"]:
                 self.menu_fav_engine_index = index
                 if not is_modern_engine and not is_retro_engine:
-                    self.state = MenuState.ENG_FAV_NAME
+                    self._sync_engine_group_selection("fav")
+                    self.state = (
+                        MenuState.ENG_FAV_MANUFACTURER
+                        if EngineProvider.get_engine_groups(EngineProvider.favorite_engines)
+                        else MenuState.ENG_FAV_NAME
+                    )
                     self.menu_engine = EngineTop.FAV_ENGINE
                 break
         self.menu_top = Top.ENGINE
 
     def set_engine_menu_sort(self, sort_order: str) -> str:
-        """Apply a live presentation-order change while retaining the retro engine index."""
+        """Apply a live presentation-order change while retaining each engine index."""
         selected_sort = EngineProvider.set_engine_menu_sort(sort_order)
-        self._sync_retro_group_selection()
+        for category in ("modern", "retro", "fav"):
+            self._sync_engine_group_selection(category)
         return selected_sort
 
-    def _sync_retro_group_selection(self):
-        groups = EngineProvider.get_retro_groups()
+    @staticmethod
+    def _engine_catalog(category: str):
+        return {
+            "modern": EngineProvider.modern_engines,
+            "retro": EngineProvider.retro_engines,
+            "fav": EngineProvider.favorite_engines,
+        }[category]
+
+    @staticmethod
+    def _engine_menu_attributes(category: str):
+        return (
+            f"menu_{category}_engine_index",
+            f"menu_{category}_manufacturer_index",
+            f"menu_{category}_group_engine_index",
+        )
+
+    def _sync_engine_group_selection(self, category: str):
+        catalog = self._engine_catalog(category)
+        engine_attr, manufacturer_attr, group_engine_attr = self._engine_menu_attributes(category)
+        groups = EngineProvider.get_engine_groups(catalog)
         if not groups:
-            self.menu_retro_manufacturer_index = 0
-            self.menu_retro_group_engine_index = 0
+            setattr(self, manufacturer_attr, 0)
+            setattr(self, group_engine_attr, 0)
             return
+        selected_engine = getattr(self, engine_attr)
         for group_index, group in enumerate(groups):
             try:
-                engine_index = group["engine_indexes"].index(self.menu_retro_engine_index)
+                engine_index = group["engine_indexes"].index(selected_engine)
             except ValueError:
                 continue
-            self.menu_retro_manufacturer_index = group_index
-            self.menu_retro_group_engine_index = engine_index
+            setattr(self, manufacturer_attr, group_index)
+            setattr(self, group_engine_attr, engine_index)
             return
-        self.menu_retro_manufacturer_index = 0
-        self.menu_retro_group_engine_index = 0
-        self.menu_retro_engine_index = groups[0]["engine_indexes"][0]
+        setattr(self, manufacturer_attr, 0)
+        setattr(self, group_engine_attr, 0)
+        setattr(self, engine_attr, groups[0]["engine_indexes"][0])
 
-    def _select_first_engine_in_retro_group(self):
-        groups = EngineProvider.get_retro_groups()
+    def _select_first_engine_in_group(self, category: str):
+        catalog = self._engine_catalog(category)
+        engine_attr, manufacturer_attr, group_engine_attr = self._engine_menu_attributes(category)
+        groups = EngineProvider.get_engine_groups(catalog)
         if not groups:
             return
-        self.menu_retro_manufacturer_index %= len(groups)
-        self.menu_retro_group_engine_index = 0
-        self.menu_retro_engine_index = groups[self.menu_retro_manufacturer_index]["engine_indexes"][0]
+        manufacturer_index = getattr(self, manufacturer_attr) % len(groups)
+        setattr(self, manufacturer_attr, manufacturer_index)
+        setattr(self, group_engine_attr, 0)
+        setattr(self, engine_attr, groups[manufacturer_index]["engine_indexes"][0])
 
-    def _step_retro_engine_in_group(self, step: int):
-        groups = EngineProvider.get_retro_groups()
+    def _step_engine_in_group(self, category: str, step: int):
+        catalog = self._engine_catalog(category)
+        engine_attr, manufacturer_attr, group_engine_attr = self._engine_menu_attributes(category)
+        groups = EngineProvider.get_engine_groups(catalog)
         if not groups:
-            indexes = EngineProvider.get_flat_retro_engine_indexes()
+            indexes = EngineProvider.get_flat_engine_indexes(catalog)
+            selected_engine = getattr(self, engine_attr)
             try:
-                current_position = indexes.index(self.menu_retro_engine_index)
+                current_position = indexes.index(selected_engine)
             except ValueError:
                 current_position = 0
-            self.menu_retro_engine_index = indexes[(current_position + step) % len(indexes)]
+            setattr(self, engine_attr, indexes[(current_position + step) % len(indexes)])
             return
-        group = groups[self.menu_retro_manufacturer_index]
+        group = groups[getattr(self, manufacturer_attr)]
         indexes = group["engine_indexes"]
-        self.menu_retro_group_engine_index = (self.menu_retro_group_engine_index + step) % len(indexes)
-        self.menu_retro_engine_index = indexes[self.menu_retro_group_engine_index]
+        group_engine_index = (getattr(self, group_engine_attr) + step) % len(indexes)
+        setattr(self, group_engine_attr, group_engine_index)
+        setattr(self, engine_attr, indexes[group_engine_index])
+
+    def _step_engine_manufacturer(self, category: str, step: int):
+        catalog = self._engine_catalog(category)
+        _, manufacturer_attr, _ = self._engine_menu_attributes(category)
+        groups = EngineProvider.get_engine_groups(catalog)
+        setattr(self, manufacturer_attr, (getattr(self, manufacturer_attr) + step) % len(groups))
+        self._select_first_engine_in_group(category)
+
+    def _sync_retro_group_selection(self):
+        """Backward-compatible wrapper for existing Retro callers and tests."""
+        self._sync_engine_group_selection("retro")
+
+    def _select_first_engine_in_retro_group(self):
+        """Backward-compatible wrapper for existing Retro callers and tests."""
+        self._select_first_engine_in_group("retro")
+
+    def _step_retro_engine_in_group(self, step: int):
+        """Backward-compatible wrapper for existing Retro callers and tests."""
+        self._step_engine_in_group("retro", step)
 
     def inside_updt_menu(self):
         """Inside update menu."""
@@ -1536,9 +1598,11 @@ class DgtMenu(object):
         text = self.dgttranslate.text(EngineTop.RETRO_ENGINE.value)
         return text
 
-    def _get_current_retro_manufacturer_name(self):
-        groups = EngineProvider.get_retro_groups()
-        manufacturer = groups[self.menu_retro_manufacturer_index]["manufacturer"]
+    def _get_current_engine_manufacturer_name(self, category: str):
+        catalog = self._engine_catalog(category)
+        _, manufacturer_attr, _ = self._engine_menu_attributes(category)
+        groups = EngineProvider.get_engine_groups(catalog)
+        manufacturer = groups[getattr(self, manufacturer_attr)]["manufacturer"]
         return Dgt.DISPLAY_TEXT(
             web_text=manufacturer,
             large_text=manufacturer[:11],
@@ -1550,11 +1614,27 @@ class DgtMenu(object):
             devs={"ser", "i2c", "web"},
         )
 
+    def enter_eng_modern_manufacturer_menu(self):
+        """Enter the optional manufacturer level of the Modern menu."""
+        self.state = MenuState.ENG_MODERN_MANUFACTURER
+        self._sync_engine_group_selection("modern")
+        return self._get_current_engine_manufacturer_name("modern")
+
+    def _get_current_retro_manufacturer_name(self):
+        """Backward-compatible Retro manufacturer text helper."""
+        return self._get_current_engine_manufacturer_name("retro")
+
     def enter_eng_retro_manufacturer_menu(self):
         """Enter the optional manufacturer level of the Retro menu."""
         self.state = MenuState.ENG_RETRO_MANUFACTURER
-        self._sync_retro_group_selection()
-        return self._get_current_retro_manufacturer_name()
+        self._sync_engine_group_selection("retro")
+        return self._get_current_engine_manufacturer_name("retro")
+
+    def enter_eng_fav_manufacturer_menu(self):
+        """Enter the optional manufacturer level of the Special menu."""
+        self.state = MenuState.ENG_FAV_MANUFACTURER
+        self._sync_engine_group_selection("fav")
+        return self._get_current_engine_manufacturer_name("fav")
 
     def enter_fav_eng_menu(self):
         """Set the menu state."""
@@ -1563,7 +1643,7 @@ class DgtMenu(object):
         return text
 
     def _get_current_modern_engine_name(self):
-        text = EngineProvider.installed_engines[self.menu_modern_engine_index]["text"]
+        text = EngineProvider.modern_engines[self.menu_modern_engine_index]["text"]
         text.beep = self.dgttranslate.bl(BeepLevel.BUTTON)
         return text
 
@@ -2124,8 +2204,14 @@ class DgtMenu(object):
         elif self.state == MenuState.ENG_MODERN:
             text = self.enter_engine_menu()
 
-        elif self.state == MenuState.ENG_MODERN_NAME:
+        elif self.state == MenuState.ENG_MODERN_MANUFACTURER:
             text = self.enter_modern_eng_menu()
+
+        elif self.state == MenuState.ENG_MODERN_NAME:
+            if EngineProvider.get_engine_groups(EngineProvider.modern_engines):
+                text = self.enter_eng_modern_manufacturer_menu()
+            else:
+                text = self.enter_modern_eng_menu()
 
         elif self.state == MenuState.ENG_MODERN_NAME_LEVEL:
             text = self.enter_eng_modern_name_menu()
@@ -2148,8 +2234,14 @@ class DgtMenu(object):
         elif self.state == MenuState.ENG_FAV:
             text = self.enter_engine_menu()
 
-        elif self.state == MenuState.ENG_FAV_NAME:
+        elif self.state == MenuState.ENG_FAV_MANUFACTURER:
             text = self.enter_fav_eng_menu()
+
+        elif self.state == MenuState.ENG_FAV_NAME:
+            if EngineProvider.get_engine_groups(EngineProvider.favorite_engines):
+                text = self.enter_eng_fav_manufacturer_menu()
+            else:
+                text = self.enter_fav_eng_menu()
 
         elif self.state == MenuState.ENG_FAV_NAME_LEVEL:
             text = self.enter_eng_fav_name_menu()
@@ -2889,6 +2981,13 @@ class DgtMenu(object):
             text = await self._fire_event(event)
 
         elif self.state == MenuState.ENG_MODERN:
+            if EngineProvider.get_engine_groups(EngineProvider.modern_engines):
+                text = self.enter_eng_modern_manufacturer_menu()
+            else:
+                text = self.enter_eng_modern_name_menu()
+
+        elif self.state == MenuState.ENG_MODERN_MANUFACTURER:
+            self._select_first_engine_in_group("modern")
             text = self.enter_eng_modern_name_menu()
 
         elif self.state == MenuState.ENG_MODERN_NAME:
@@ -2966,6 +3065,13 @@ class DgtMenu(object):
             self.res_engine_level = self.menu_retro_engine_level
 
         elif self.state == MenuState.ENG_FAV:
+            if EngineProvider.get_engine_groups(EngineProvider.favorite_engines):
+                text = self.enter_eng_fav_manufacturer_menu()
+            else:
+                text = self.enter_eng_fav_name_menu()
+
+        elif self.state == MenuState.ENG_FAV_MANUFACTURER:
+            self._select_first_engine_in_group("fav")
             text = self.enter_eng_fav_name_menu()
 
         elif self.state == MenuState.ENG_FAV_NAME:
@@ -3841,8 +3947,12 @@ class DgtMenu(object):
             self.menu_engine = EngineTopLoop.prev(self.menu_engine)
             text = self.dgttranslate.text(self.menu_engine.value)
 
+        elif self.state == MenuState.ENG_MODERN_MANUFACTURER:
+            self._step_engine_manufacturer("modern", -1)
+            text = self._get_current_engine_manufacturer_name("modern")
+
         elif self.state == MenuState.ENG_MODERN_NAME:
-            self.menu_modern_engine_index = (self.menu_modern_engine_index - 1) % len(EngineProvider.modern_engines)
+            self._step_engine_in_group("modern", -1)
             text = self._get_current_modern_engine_name()
 
         elif self.state == MenuState.ENG_MODERN_NAME_LEVEL:
@@ -3857,10 +3967,8 @@ class DgtMenu(object):
             text = self.dgttranslate.text(self.menu_engine.value)
 
         elif self.state == MenuState.ENG_RETRO_MANUFACTURER:
-            groups = EngineProvider.get_retro_groups()
-            self.menu_retro_manufacturer_index = (self.menu_retro_manufacturer_index - 1) % len(groups)
-            self._select_first_engine_in_retro_group()
-            text = self._get_current_retro_manufacturer_name()
+            self._step_engine_manufacturer("retro", -1)
+            text = self._get_current_engine_manufacturer_name("retro")
 
         elif self.state == MenuState.ENG_RETRO_NAME:
             self._step_retro_engine_in_group(-1)
@@ -3877,8 +3985,12 @@ class DgtMenu(object):
             self.menu_engine = EngineTopLoop.prev(self.menu_engine)
             text = self.dgttranslate.text(self.menu_engine.value)
 
+        elif self.state == MenuState.ENG_FAV_MANUFACTURER:
+            self._step_engine_manufacturer("fav", -1)
+            text = self._get_current_engine_manufacturer_name("fav")
+
         elif self.state == MenuState.ENG_FAV_NAME:
-            self.menu_fav_engine_index = (self.menu_fav_engine_index - 1) % len(EngineProvider.favorite_engines)
+            self._step_engine_in_group("fav", -1)
             text = self._get_current_fav_engine_name()
 
         elif self.state == MenuState.ENG_FAV_NAME_LEVEL:
@@ -4533,8 +4645,12 @@ class DgtMenu(object):
             self.menu_engine = EngineTopLoop.next(self.menu_engine)
             text = self.dgttranslate.text(self.menu_engine.value)
 
+        elif self.state == MenuState.ENG_MODERN_MANUFACTURER:
+            self._step_engine_manufacturer("modern", 1)
+            text = self._get_current_engine_manufacturer_name("modern")
+
         elif self.state == MenuState.ENG_MODERN_NAME:
-            self.menu_modern_engine_index = (self.menu_modern_engine_index + 1) % len(EngineProvider.modern_engines)
+            self._step_engine_in_group("modern", 1)
             text = self._get_current_modern_engine_name()
 
         elif self.state == MenuState.ENG_MODERN_NAME_LEVEL:
@@ -4549,10 +4665,8 @@ class DgtMenu(object):
             text = self.dgttranslate.text(self.menu_engine.value)
 
         elif self.state == MenuState.ENG_RETRO_MANUFACTURER:
-            groups = EngineProvider.get_retro_groups()
-            self.menu_retro_manufacturer_index = (self.menu_retro_manufacturer_index + 1) % len(groups)
-            self._select_first_engine_in_retro_group()
-            text = self._get_current_retro_manufacturer_name()
+            self._step_engine_manufacturer("retro", 1)
+            text = self._get_current_engine_manufacturer_name("retro")
 
         elif self.state == MenuState.ENG_RETRO_NAME:
             self._step_retro_engine_in_group(1)
@@ -4569,8 +4683,12 @@ class DgtMenu(object):
             self.menu_engine = EngineTopLoop.next(self.menu_engine)
             text = self.dgttranslate.text(self.menu_engine.value)
 
+        elif self.state == MenuState.ENG_FAV_MANUFACTURER:
+            self._step_engine_manufacturer("fav", 1)
+            text = self._get_current_engine_manufacturer_name("fav")
+
         elif self.state == MenuState.ENG_FAV_NAME:
-            self.menu_fav_engine_index = (self.menu_fav_engine_index + 1) % len(EngineProvider.favorite_engines)
+            self._step_engine_in_group("fav", 1)
             text = self._get_current_fav_engine_name()
 
         elif self.state == MenuState.ENG_FAV_NAME_LEVEL:

--- a/picochess.ini.example-dgtpi-clock
+++ b/picochess.ini.example-dgtpi-clock
@@ -78,6 +78,9 @@ engine = /opt/picochess/engines/aarch64/a-stockf
 ## For a (correct) value please take a look at 'engines/<your_platform>/<engine_name>.uci'
 engine-level = Elo@2200
 
+## Retro engine menu ordering: file, engine, or manufacturer. Default is file.
+#engine-menu-sort = file
+
 ### =========================
 ### = Remote engine options =
 ### =========================

--- a/picochess.ini.example-web-aarch64
+++ b/picochess.ini.example-web-aarch64
@@ -78,6 +78,9 @@ engine = /opt/picochess/engines/aarch64/a-stockf
 ## For a (correct) value please take a look at 'engines/<your_platform>/<engine_name>.uci'
 engine-level = Elo@2200
 
+## Retro engine menu ordering: file, engine, or manufacturer. Default is file.
+#engine-menu-sort = file
+
 ### =========================
 ### = Remote engine options =
 ### =========================

--- a/picochess.ini.example-web-x86_64
+++ b/picochess.ini.example-web-x86_64
@@ -78,6 +78,9 @@ engine = /opt/picochess/engines/x86_64/a-stockf
 ## For a (correct) value please take a look at 'engines/<your_platform>/<engine_name>.uci'
 engine-level = Elo@2200
 
+## Retro engine menu ordering: file, engine, or manufacturer. Default is file.
+#engine-menu-sort = file
+
 ### =========================
 ### = Remote engine options =
 ### =========================

--- a/picochess.py
+++ b/picochess.py
@@ -1258,7 +1258,7 @@ async def main() -> None:
     if unknown:
         logger.warning("invalid parameter given %s", unknown)
 
-    EngineProvider.init()
+    EngineProvider.init(args.engine_menu_sort)
 
     Rev2Info.set_dgtpi(args.dgtpi)
     state.flag_flexible_ponder = args.flexible_analysis

--- a/server.py
+++ b/server.py
@@ -352,6 +352,50 @@ def _engine_change_events(eng: dict, level_name: str, dgttranslate):
     )
 
 
+def _engine_menu_payload() -> dict:
+    """Serialize engine choices in presentation order without changing catalog indexes."""
+    from uci.engine_provider import EngineProvider
+
+    engines = []
+
+    def _entry(engine, category, manufacturer=""):
+        return {
+            "name": engine.get("name", ""),
+            "file": engine.get("file", ""),
+            "elo": engine.get("elo", ""),
+            "levels": list(engine.get("level_dict", {}).keys()),
+            "category": category,
+            "manufacturer": manufacturer,
+        }
+
+    engines.extend(_entry(engine, "modern") for engine in EngineProvider.modern_engines)
+    retro_groups = EngineProvider.get_retro_groups()
+    if retro_groups:
+        for group in retro_groups:
+            engines.extend(
+                _entry(EngineProvider.retro_engines[index], "retro", group["manufacturer"])
+                for index in group["engine_indexes"]
+            )
+    else:
+        engines.extend(_entry(engine, "retro") for engine in EngineProvider.retro_engines)
+    engines.extend(_entry(engine, "favorites") for engine in EngineProvider.favorite_engines)
+    return {"engines": engines, "engine_menu_sort": EngineProvider.engine_menu_sort}
+
+
+def _apply_engine_menu_sort(shared: dict, sort_order: str):
+    """Persist and apply a valid live Retro-menu presentation order."""
+    from uci.engine_provider import EngineProvider
+
+    requested = str(sort_order or "").strip().lower()
+    if requested not in ("file", "engine", "manufacturer"):
+        return None
+    dgtmenu = shared.get("dgtmenu")
+    selected = dgtmenu.set_engine_menu_sort(requested) if dgtmenu else EngineProvider.set_engine_menu_sort(requested)
+    write_picochess_ini("engine-menu-sort", selected)
+    shared.setdefault("system_info", {})["engine_menu_sort"] = selected
+    return selected
+
+
 def _text_to_label(text_obj) -> str:
     """Extract a plain string from a DGT Text object or passthrough if already a str."""
     if text_obj is None:
@@ -971,6 +1015,17 @@ class ChannelHandler(ServerRequestHandler):
             if eng:
                 for event in _engine_change_events(eng, level, dgttranslate):
                     await Observable.fire(event)
+        elif action == "engine_menu_sort":
+            selected_sort = _apply_engine_menu_sort(self.shared, self.get_argument("val", ""))
+            self.set_header("Content-Type", "application/json")
+            if selected_sort is None:
+                self.set_status(400)
+                self.write({"success": False, "error": "Invalid engine menu sort order"})
+            else:
+                EventHandler.write_to_clients(
+                    {"event": "SystemInfo", "msg": {"engine_menu_sort": selected_sort}}
+                )
+                self.write({"success": True, "engine_menu_sort": selected_sort})
         elif action == "new_engine_book":
             selected = _select_engine_book(self.get_argument("file", ""))
             if selected:
@@ -1554,27 +1609,8 @@ class InfoHandler(ServerRequestHandler):
         if action == "get_clock_menu_state":
             self.write({"active": _clock_menu_active(self.shared)})
         if action == "get_engines":
-            from uci.engine_provider import EngineProvider
-
-            engines = []
-
-            def _add(eng_list, category):
-                for eng in eng_list:
-                    engines.append(
-                        {
-                            "name": eng.get("name", ""),
-                            "file": eng.get("file", ""),
-                            "elo": eng.get("elo", ""),
-                            "levels": list(eng.get("level_dict", {}).keys()),
-                            "category": category,
-                        }
-                    )
-
-            _add(EngineProvider.modern_engines, "modern")
-            _add(EngineProvider.retro_engines, "retro")
-            _add(EngineProvider.favorite_engines, "favorites")
             self.set_header("Content-Type", "application/json")
-            self.write(json.dumps({"engines": engines}))
+            self.write(json.dumps(_engine_menu_payload()))
         if action == "get_voices":
             # Return available speakers for the current language.
             # Speakers are sub-directories of talker/voices/{lang}/.
@@ -1620,6 +1656,9 @@ class InfoHandler(ServerRequestHandler):
                 settings["capital"] = "on" if ecl in (True, "True", "true") else "off"
                 se = config.get("show-engine")
                 settings["show_engine"] = "on" if se in (True, "True", "true") else "off"
+                from uci.engine_provider import EngineProvider
+
+                settings["engine_menu_sort"] = EngineProvider.engine_menu_sort
                 # Retro speed (stored as float 0.0–10.0; UI shows as % strings)
                 try:
                     rspeed_f = float(config.get("rspeed", 1.0))

--- a/server.py
+++ b/server.py
@@ -377,7 +377,10 @@ def _engine_menu_payload() -> dict:
                 for index in group["engine_indexes"]
             )
     else:
-        engines.extend(_entry(engine, "retro") for engine in EngineProvider.retro_engines)
+        engines.extend(
+            _entry(EngineProvider.retro_engines[index], "retro")
+            for index in EngineProvider.get_flat_retro_engine_indexes()
+        )
     engines.extend(_entry(engine, "favorites") for engine in EngineProvider.favorite_engines)
     return {"engines": engines, "engine_menu_sort": EngineProvider.engine_menu_sort}
 

--- a/server.py
+++ b/server.py
@@ -368,20 +368,23 @@ def _engine_menu_payload() -> dict:
             "manufacturer": manufacturer,
         }
 
-    engines.extend(_entry(engine, "modern") for engine in EngineProvider.modern_engines)
-    retro_groups = EngineProvider.get_retro_groups()
-    if retro_groups:
-        for group in retro_groups:
-            engines.extend(
-                _entry(EngineProvider.retro_engines[index], "retro", group["manufacturer"])
-                for index in group["engine_indexes"]
-            )
-    else:
+    def _extend_category(catalog, category):
+        groups = EngineProvider.get_engine_groups(catalog)
+        if groups:
+            for group in groups:
+                engines.extend(
+                    _entry(catalog[index], category, group["manufacturer"])
+                    for index in group["engine_indexes"]
+                )
+            return
         engines.extend(
-            _entry(EngineProvider.retro_engines[index], "retro")
-            for index in EngineProvider.get_flat_retro_engine_indexes()
+            _entry(catalog[index], category)
+            for index in EngineProvider.get_flat_engine_indexes(catalog)
         )
-    engines.extend(_entry(engine, "favorites") for engine in EngineProvider.favorite_engines)
+
+    _extend_category(EngineProvider.modern_engines, "modern")
+    _extend_category(EngineProvider.retro_engines, "retro")
+    _extend_category(EngineProvider.favorite_engines, "favorites")
     return {"engines": engines, "engine_menu_sort": EngineProvider.engine_menu_sort}
 
 

--- a/server.py
+++ b/server.py
@@ -412,10 +412,20 @@ def _text_to_label(text_obj) -> str:
     return ""
 
 
+def _sorted_opening_books():
+    """Return opening books alphabetically by their visible label."""
+    def _sort_key(book):
+        book_file = str(book.get("file", "")).strip()
+        label = _text_to_label(book.get("text")) or os.path.basename(book_file)
+        return label.casefold(), book_file.casefold()
+
+    return sorted(get_opening_books(), key=_sort_key)
+
+
 def _web_book_choices():
     """Return the web book-picker choices including the ObookSrv pseudo-entry."""
     books = [{"index": 0, "file": OBOOKSRV_BOOK_FILE, "label": OBOOKSRV_BOOK_LABEL}]
-    for offset, book in enumerate(get_opening_books(), start=1):
+    for offset, book in enumerate(_sorted_opening_books(), start=1):
         books.append(
             {
                 "index": offset,
@@ -441,7 +451,7 @@ def _configured_engine_book_file() -> str:
 def _engine_book_choices():
     """Return the real engine-book choices, excluding the ObookSrv pseudo-entry."""
     choices = []
-    for index, book in enumerate(get_opening_books()):
+    for index, book in enumerate(_sorted_opening_books()):
         choices.append(
             {
                 "index": index,
@@ -455,7 +465,7 @@ def _engine_book_choices():
 def _select_engine_book(book_file: str):
     """Resolve a real engine-book file to the matching configured book entry."""
     selected_file = str(book_file or "").strip()
-    library = get_opening_books()
+    library = _sorted_opening_books()
     if not library:
         return None
     for index, book in enumerate(library):

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -244,6 +244,36 @@ class TestDgtMenu(unittest.IsolatedAsyncioTestCase):
         self.assertEqual("Alpha", EngineProvider.get_retro_groups()[0]["manufacturer"])
 
     @patch("platform.machine")
+    async def test_grouped_modern_and_special_engine_menus(self, machine_mock):
+        menu = self.create_menu(machine_mock)
+        for engine, manufacturer in zip(EngineProvider.modern_engines, ["Open Source", "Other", "Other"]):
+            engine["manufacturer"] = manufacturer
+        for engine, manufacturer in zip(EngineProvider.favorite_engines, ["Favorites", "Favorites", "Classic"]):
+            engine["manufacturer"] = manufacturer
+
+        menu.enter_modern_eng_menu()
+        manufacturer = await menu.main_down()
+        self.assertEqual(MenuState.ENG_MODERN_MANUFACTURER, menu.state)
+        self.assertEqual("Open Source", manufacturer.web_text)
+        engine_name = await menu.main_down()
+        self.assertEqual(MenuState.ENG_MODERN_NAME, menu.state)
+        self.assertEqual(0, menu.menu_modern_engine_index)
+        menu.main_up()
+        self.assertEqual(MenuState.ENG_MODERN_MANUFACTURER, menu.state)
+
+        menu.enter_fav_eng_menu()
+        manufacturer = await menu.main_down()
+        self.assertEqual(MenuState.ENG_FAV_MANUFACTURER, menu.state)
+        self.assertEqual("Favorites", manufacturer.web_text)
+        menu.main_right()
+        engine_name = await menu.main_down()
+        self.assertEqual(MenuState.ENG_FAV_NAME, menu.state)
+        self.assertEqual(2, menu.menu_fav_engine_index)
+        self.assertEqual(EngineProvider.favorite_engines[2]["text"].large_text, engine_name.large_text)
+        menu.main_up()
+        self.assertEqual(MenuState.ENG_FAV_MANUFACTURER, menu.state)
+
+    @patch("platform.machine")
     async def test_flat_retro_engine_sort_changes_navigation_not_indexes(self, machine_mock):
         menu = self.create_menu(machine_mock)
         original_names = [engine["name"] for engine in EngineProvider.retro_engines]

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -20,6 +20,7 @@ class TestDgtMenu(unittest.IsolatedAsyncioTestCase):
         EngineProvider.installed_engines = list(
             EngineProvider.modern_engines + EngineProvider.retro_engines + EngineProvider.favorite_engines
         )
+        EngineProvider.set_engine_menu_sort("file")
 
         trans = DgtTranslate("none", 0, "en", "version")
         menu = DgtMenu(
@@ -241,6 +242,25 @@ class TestDgtMenu(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(1, menu.menu_retro_engine_index)
         self.assertEqual(0, menu.menu_retro_manufacturer_index)
         self.assertEqual("Alpha", EngineProvider.get_retro_groups()[0]["manufacturer"])
+
+    @patch("platform.machine")
+    async def test_flat_retro_engine_sort_changes_navigation_not_indexes(self, machine_mock):
+        menu = self.create_menu(machine_mock)
+        original_names = [engine["name"] for engine in EngineProvider.retro_engines]
+        expected_indexes = sorted(
+            range(len(EngineProvider.retro_engines)),
+            key=lambda index: (EngineProvider.retro_engines[index]["name"].casefold(), index),
+        )
+        menu.menu_retro_engine_index = expected_indexes[0]
+        menu.set_engine_menu_sort("engine")
+
+        menu.enter_retro_eng_menu()
+        await menu.main_down()
+        self.assertEqual(MenuState.ENG_RETRO_NAME, menu.state)
+        menu.main_right()
+
+        self.assertEqual(expected_indexes[1], menu.menu_retro_engine_index)
+        self.assertEqual(original_names, [engine["name"] for engine in EngineProvider.retro_engines])
 
     @patch("platform.machine")
     async def test_modern_engine_retrieval(self, machine_mock):

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -202,6 +202,47 @@ class TestDgtMenu(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(MenuState.ENG_RETRO_NAME, menu.state)
 
     @patch("platform.machine")
+    async def test_grouped_retro_engine_menu_traversal_uses_stable_indexes(self, machine_mock):
+        menu = self.create_menu(machine_mock)
+        manufacturers = ["Mephisto", "Mephisto", "Novag"]
+        for engine, manufacturer in zip(EngineProvider.retro_engines, manufacturers):
+            engine["manufacturer"] = manufacturer
+        EngineProvider.set_engine_menu_sort("file")
+
+        menu.enter_retro_eng_menu()
+        manufacturer = await menu.main_down()
+        self.assertEqual(MenuState.ENG_RETRO_MANUFACTURER, menu.state)
+        self.assertEqual("Mephisto", manufacturer.web_text)
+
+        manufacturer = menu.main_right()
+        self.assertEqual("Novag", manufacturer.web_text)
+        engine_name = await menu.main_down()
+        self.assertEqual(MenuState.ENG_RETRO_NAME, menu.state)
+        self.assertEqual(2, menu.menu_retro_engine_index)
+        self.assertEqual(EngineProvider.retro_engines[2]["text"].large_text, engine_name.large_text)
+
+        menu.main_up()
+        self.assertEqual(MenuState.ENG_RETRO_MANUFACTURER, menu.state)
+        menu.main_left()
+        await menu.main_down()
+        self.assertEqual(0, menu.menu_retro_engine_index)
+        menu.main_right()
+        self.assertEqual(1, menu.menu_retro_engine_index)
+
+    @patch("platform.machine")
+    async def test_grouped_retro_sort_change_retains_current_engine(self, machine_mock):
+        menu = self.create_menu(machine_mock)
+        EngineProvider.retro_engines[0]["manufacturer"] = "Zulu"
+        EngineProvider.retro_engines[1]["manufacturer"] = "Alpha"
+        menu.menu_retro_engine_index = 1
+
+        menu.set_engine_menu_sort("manufacturer")
+
+        self.assertEqual(1, menu.menu_retro_engine_index)
+        self.assertEqual(0, menu.menu_retro_manufacturer_index)
+        self.assertEqual("Alpha", EngineProvider.get_retro_groups()[0]["manufacturer"])
+
+    @patch("platform.machine")
     async def test_modern_engine_retrieval(self, machine_mock):
         menu = self.create_menu(machine_mock)
         menu.set_state_current_engine("")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -25,6 +25,8 @@ from server import (
     _display_text_from_label,
     _engine_book_choices,
     _engine_change_events,
+    _engine_menu_payload,
+    _apply_engine_menu_sort,
     _mode_text,
     _orient_scanned_board_fen,
     _retag_setup_position_side,
@@ -35,6 +37,7 @@ from server import (
     _validate_setup_position_fen,
     _web_book_choices,
 )
+from uci.engine_provider import EngineProvider
 from utilities import version as pico_version
 
 
@@ -88,6 +91,70 @@ class TestServerDisplayTextHelpers(unittest.TestCase):
         text = _display_text_from_label("PGN Replay")
         self.assert_display_text(text)
         self.assertEqual("PGN Replay", text.web_text)
+
+
+class TestEngineMenuHelpers(unittest.TestCase):
+    def setUp(self):
+        self.original_modern = EngineProvider.modern_engines
+        self.original_retro = EngineProvider.retro_engines
+        self.original_favorites = EngineProvider.favorite_engines
+        self.original_sort = EngineProvider.engine_menu_sort
+        EngineProvider.modern_engines = [{"name": "Modern", "file": "modern", "level_dict": {}}]
+        EngineProvider.favorite_engines = [{"name": "Favorite", "file": "favorite", "level_dict": {}}]
+
+    def tearDown(self):
+        EngineProvider.modern_engines = self.original_modern
+        EngineProvider.retro_engines = self.original_retro
+        EngineProvider.favorite_engines = self.original_favorites
+        EngineProvider.engine_menu_sort = self.original_sort
+
+    def test_payload_uses_grouped_presentation_order_and_original_files(self):
+        EngineProvider.retro_engines = [
+            {"name": "Zulu", "file": "retro-0", "level_dict": {}, "manufacturer": "Novag"},
+            {"name": "Beta", "file": "retro-1", "level_dict": {}, "manufacturer": "Mephisto"},
+            {"name": "Alpha", "file": "retro-2", "level_dict": {}, "manufacturer": "Novag"},
+        ]
+        EngineProvider.set_engine_menu_sort("manufacturer")
+
+        payload = _engine_menu_payload()
+        retro = [entry for entry in payload["engines"] if entry["category"] == "retro"]
+
+        self.assertEqual("manufacturer", payload["engine_menu_sort"])
+        self.assertEqual(["retro-1", "retro-2", "retro-0"], [entry["file"] for entry in retro])
+        self.assertEqual(["Mephisto", "Novag", "Novag"], [entry["manufacturer"] for entry in retro])
+
+    def test_payload_keeps_legacy_retro_entries_flat(self):
+        EngineProvider.retro_engines = [{"name": "Retro", "file": "retro", "level_dict": {}}]
+
+        payload = _engine_menu_payload()
+        retro = [entry for entry in payload["engines"] if entry["category"] == "retro"]
+
+        self.assertEqual("", retro[0]["manufacturer"])
+
+    @patch("server.write_picochess_ini")
+    def test_apply_sort_updates_live_dgt_menu_and_persists(self, write_ini):
+        class FakeDgtMenu:
+            def __init__(self):
+                self.value = None
+
+            def set_engine_menu_sort(self, value):
+                self.value = value
+                return EngineProvider.set_engine_menu_sort(value)
+
+        menu = FakeDgtMenu()
+        shared = {"dgtmenu": menu}
+
+        result = _apply_engine_menu_sort(shared, "engine")
+
+        self.assertEqual("engine", result)
+        self.assertEqual("engine", menu.value)
+        self.assertEqual("engine", shared["system_info"]["engine_menu_sort"])
+        write_ini.assert_called_once_with("engine-menu-sort", "engine")
+
+    @patch("server.write_picochess_ini")
+    def test_apply_sort_rejects_unknown_value(self, write_ini):
+        self.assertIsNone(_apply_engine_menu_sort({}, "elo"))
+        write_ini.assert_not_called()
 
 
 class TestServerClockMenuHelpers(unittest.TestCase):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -124,11 +124,16 @@ class TestEngineMenuHelpers(unittest.TestCase):
         self.assertEqual(["Mephisto", "Novag", "Novag"], [entry["manufacturer"] for entry in retro])
 
     def test_payload_keeps_legacy_retro_entries_flat(self):
-        EngineProvider.retro_engines = [{"name": "Retro", "file": "retro", "level_dict": {}}]
+        EngineProvider.retro_engines = [
+            {"name": "Zulu", "file": "retro-0", "level_dict": {}},
+            {"name": "Alpha", "file": "retro-1", "level_dict": {}},
+        ]
+        EngineProvider.set_engine_menu_sort("engine")
 
         payload = _engine_menu_payload()
         retro = [entry for entry in payload["engines"] if entry["category"] == "retro"]
 
+        self.assertEqual(["retro-1", "retro-0"], [entry["file"] for entry in retro])
         self.assertEqual("", retro[0]["manufacturer"])
 
     @patch("server.write_picochess_ini")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -137,6 +137,25 @@ class TestEngineMenuHelpers(unittest.TestCase):
         self.assertEqual(["retro-1", "retro-0"], [entry["file"] for entry in retro])
         self.assertEqual("", retro[0]["manufacturer"])
 
+    def test_payload_groups_modern_and_favorites_when_metadata_exists(self):
+        EngineProvider.modern_engines = [
+            {"name": "Zulu", "file": "modern-0", "level_dict": {}, "manufacturer": ""},
+            {"name": "Alpha", "file": "modern-1", "level_dict": {}, "manufacturer": "Maker"},
+        ]
+        EngineProvider.retro_engines = []
+        EngineProvider.favorite_engines = [
+            {"name": "Beta", "file": "fav-0", "level_dict": {}, "manufacturer": "Studio"},
+        ]
+        EngineProvider.set_engine_menu_sort("manufacturer")
+
+        payload = _engine_menu_payload()
+        modern = [entry for entry in payload["engines"] if entry["category"] == "modern"]
+        favorites = [entry for entry in payload["engines"] if entry["category"] == "favorites"]
+
+        self.assertEqual(["modern-1", "modern-0"], [entry["file"] for entry in modern])
+        self.assertEqual(["Maker", "Other"], [entry["manufacturer"] for entry in modern])
+        self.assertEqual(["Studio"], [entry["manufacturer"] for entry in favorites])
+
     @patch("server.write_picochess_ini")
     def test_apply_sort_updates_live_dgt_menu_and_persists(self, write_ini):
         class FakeDgtMenu:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -12,6 +12,7 @@ from dgt.util import GameResult, Mode, PicoCoach, PlayMode, TimeMode
 from server import (
     WebDisplay,
     OBOOKSRV_BOOK_FILE,
+    OBOOKSRV_BOOK_LABEL,
     _apply_web_analysis_state,
     _build_scanned_setup_board,
     _cached_setup_position_fen,
@@ -263,6 +264,22 @@ class TestServerWebBookSelection(unittest.TestCase):
         self.assertEqual(OBOOKSRV_BOOK_FILE, selected["file"])
         self.assertNotIn("system_info", shared)
 
+    @patch("server.get_opening_books")
+    def test_web_books_are_alphabetical_after_obooksrv(self, get_opening_books):
+        get_opening_books.return_value = [
+            {"file": "zulu.bin", "text": "Zulu"},
+            {"file": "alpha.bin", "text": "Alpha"},
+            {"file": "beta.bin", "text": "beta"},
+        ]
+
+        books = _web_book_choices()
+
+        self.assertEqual(
+            [OBOOKSRV_BOOK_LABEL, "Alpha", "beta", "Zulu"],
+            [book["label"] for book in books],
+        )
+        self.assertEqual([0, 1, 2, 3], [book["index"] for book in books])
+
 
 class TestServerWebEngineSelection(unittest.TestCase):
     def setUp(self):
@@ -324,6 +341,19 @@ class TestServerEngineBookSelection(unittest.TestCase):
         self.assertIsNotNone(selected)
         self.assertNotEqual(OBOOKSRV_BOOK_FILE, selected["file"])
         self.assertTrue(selected["label"])
+
+    @patch("server.get_opening_books")
+    def test_engine_books_are_alphabetical(self, get_opening_books):
+        get_opening_books.return_value = [
+            {"file": "zulu.bin", "text": "Zulu"},
+            {"file": "alpha.bin", "text": "Alpha"},
+            {"file": "beta.bin", "text": "beta"},
+        ]
+
+        books = _engine_book_choices()
+
+        self.assertEqual(["Alpha", "beta", "Zulu"], [book["label"] for book in books])
+        self.assertEqual([0, 1, 2], [book["index"] for book in books])
 
 
 class TestServerWebAnalysisState(unittest.TestCase):

--- a/tests/uci/test_engine_provider.py
+++ b/tests/uci/test_engine_provider.py
@@ -44,6 +44,24 @@ class TestEngineProvider(unittest.TestCase):
         EngineProvider.retro_engines = [{"name": "One"}, {"name": "Two"}]
         self.assertEqual([], EngineProvider.get_retro_groups())
 
+    def test_generic_groups_are_absent_without_metadata(self):
+        engines = [{"name": "One", "manufacturer": ""}, {"name": "Two"}]
+        self.assertEqual([], EngineProvider.get_engine_groups(engines))
+
+    def test_generic_groups_collect_missing_metadata_under_other(self):
+        engines = [
+            {"name": "Zulu", "manufacturer": ""},
+            {"name": "Beta", "manufacturer": "Maker"},
+        ]
+        EngineProvider.set_engine_menu_sort("manufacturer")
+        self.assertEqual(
+            [
+                {"manufacturer": "Maker", "engine_indexes": [1]},
+                {"manufacturer": "Other", "engine_indexes": [0]},
+            ],
+            EngineProvider.get_engine_groups(engines),
+        )
+
     def test_flat_retro_engine_sort_preserves_original_indexes(self):
         EngineProvider.retro_engines = [{"name": "Zulu"}, {"name": "Alpha"}, {"name": "Beta"}]
         EngineProvider.set_engine_menu_sort("engine")

--- a/tests/uci/test_engine_provider.py
+++ b/tests/uci/test_engine_provider.py
@@ -6,6 +6,8 @@ from uci.engine_provider import EngineProvider
 class TestEngineProvider(unittest.TestCase):
     def setUp(self):
         self.original_installed_engines = EngineProvider.installed_engines
+        self.original_retro_engines = EngineProvider.retro_engines
+        self.original_engine_menu_sort = EngineProvider.engine_menu_sort
         EngineProvider.installed_engines = [
             {"file": "/opt/picochess/engines/test/first"},
             {"file": "/opt/picochess/engines/test/second"},
@@ -13,6 +15,8 @@ class TestEngineProvider(unittest.TestCase):
 
     def tearDown(self):
         EngineProvider.installed_engines = self.original_installed_engines
+        EngineProvider.retro_engines = self.original_retro_engines
+        EngineProvider.engine_menu_sort = self.original_engine_menu_sort
 
     def test_resolve_engine_matches_absolute_path(self):
         engine = EngineProvider.resolve_engine("/opt/picochess/engines/test/second")
@@ -35,3 +39,57 @@ class TestEngineProvider(unittest.TestCase):
 
     def test_has_engine_is_false_for_missing_engine(self):
         self.assertFalse(EngineProvider.has_engine("/opt/picochess/engines/test/missing"))
+
+    def test_retro_groups_are_absent_without_metadata(self):
+        EngineProvider.retro_engines = [{"name": "One"}, {"name": "Two"}]
+        self.assertEqual([], EngineProvider.get_retro_groups())
+
+    def test_retro_groups_keep_original_indexes_in_file_order(self):
+        EngineProvider.retro_engines = [
+            {"name": "Zulu", "manufacturer": ""},
+            {"name": "Beta", "manufacturer": "Novag"},
+            {"name": "Alpha", "manufacturer": "Novag"},
+            {"name": "Academy", "manufacturer": "Mephisto"},
+        ]
+        EngineProvider.set_engine_menu_sort("file")
+        self.assertEqual(
+            [
+                {"manufacturer": "Other", "engine_indexes": [0]},
+                {"manufacturer": "Novag", "engine_indexes": [1, 2]},
+                {"manufacturer": "Mephisto", "engine_indexes": [3]},
+            ],
+            EngineProvider.get_retro_groups(),
+        )
+
+    def test_engine_sort_only_sorts_engines_within_file_order_groups(self):
+        EngineProvider.retro_engines = [
+            {"name": "Zulu", "manufacturer": "Novag"},
+            {"name": "Beta", "manufacturer": "Mephisto"},
+            {"name": "Alpha", "manufacturer": "Novag"},
+        ]
+        EngineProvider.set_engine_menu_sort("engine")
+        self.assertEqual(
+            [
+                {"manufacturer": "Novag", "engine_indexes": [2, 0]},
+                {"manufacturer": "Mephisto", "engine_indexes": [1]},
+            ],
+            EngineProvider.get_retro_groups(),
+        )
+
+    def test_manufacturer_sort_sorts_groups_and_engines_without_mutating_catalog(self):
+        engines = [
+            {"name": "Zulu", "manufacturer": "Novag"},
+            {"name": "Beta", "manufacturer": "Mephisto"},
+            {"name": "Alpha", "manufacturer": "Novag"},
+        ]
+        EngineProvider.retro_engines = engines
+        EngineProvider.set_engine_menu_sort("manufacturer")
+        self.assertEqual(
+            [
+                {"manufacturer": "Mephisto", "engine_indexes": [1]},
+                {"manufacturer": "Novag", "engine_indexes": [2, 0]},
+            ],
+            EngineProvider.get_retro_groups(),
+        )
+        self.assertIs(engines, EngineProvider.retro_engines)
+        self.assertEqual(["Zulu", "Beta", "Alpha"], [engine["name"] for engine in engines])

--- a/tests/uci/test_engine_provider.py
+++ b/tests/uci/test_engine_provider.py
@@ -44,6 +44,11 @@ class TestEngineProvider(unittest.TestCase):
         EngineProvider.retro_engines = [{"name": "One"}, {"name": "Two"}]
         self.assertEqual([], EngineProvider.get_retro_groups())
 
+    def test_flat_retro_engine_sort_preserves_original_indexes(self):
+        EngineProvider.retro_engines = [{"name": "Zulu"}, {"name": "Alpha"}, {"name": "Beta"}]
+        EngineProvider.set_engine_menu_sort("engine")
+        self.assertEqual([1, 2, 0], EngineProvider.get_flat_retro_engine_indexes())
+
     def test_retro_groups_keep_original_indexes_in_file_order(self):
         EngineProvider.retro_engines = [
             {"name": "Zulu", "manufacturer": ""},

--- a/tests/uci/test_read.py
+++ b/tests/uci/test_read.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 import unittest
+from unittest.mock import patch
 
 from uci.read import read_engine_ini
 
@@ -65,3 +66,7 @@ class TestReadEngineIniManufacturer(unittest.TestCase):
             ENGINE_SECTION.format(section="one", name="One"),
         )
         self.assertEqual("", engines[0]["manufacturer"])
+
+    @patch("builtins.open", side_effect=PermissionError("catalog is not readable"))
+    def test_unreadable_engine_ini_keeps_previous_empty_catalog_fallback(self, _open):
+        self.assertEqual([], read_engine_ini(engine_path="/engines", filename="retro.ini"))

--- a/tests/uci/test_read.py
+++ b/tests/uci/test_read.py
@@ -1,0 +1,60 @@
+import os
+import tempfile
+import unittest
+
+from uci.read import read_engine_ini
+
+
+ENGINE_SECTION = """\
+[{section}]
+name = {name}
+small = small
+medium = medium
+large = large
+elo = 1500
+"""
+
+
+class TestReadEngineIniManufacturer(unittest.TestCase):
+    def _read(self, filename, content):
+        with tempfile.TemporaryDirectory() as engine_path:
+            with open(os.path.join(engine_path, filename), "w", encoding="utf-8") as ini_file:
+                ini_file.write(content)
+            return read_engine_ini(engine_path=engine_path, filename=filename)
+
+    def test_strict_manufacturer_applies_until_next_directive(self):
+        engines = self._read(
+            "retro.ini",
+            "; Manufacturer: Mephisto\n"
+            + ENGINE_SECTION.format(section="mame/one", name="One")
+            + ENGINE_SECTION.format(section="mame/two", name="Two")
+            + "; Manufacturer: Novag\n"
+            + ENGINE_SECTION.format(section="mame/three", name="Three"),
+        )
+        self.assertEqual(["Mephisto", "Mephisto", "Novag"], [engine["manufacturer"] for engine in engines])
+
+    def test_ordinary_and_malformed_comments_are_ignored(self):
+        engines = self._read(
+            "retro.ini",
+            "; Manufacturer: Mephisto\n"
+            + ENGINE_SECTION.format(section="mame/one", name="One")
+            + "; ordinary comment\n;Manufacturer: Novag\n; manufacturer: Novag\n"
+            + ENGINE_SECTION.format(section="mame/two", name="Two"),
+        )
+        self.assertEqual(["Mephisto", "Mephisto"], [engine["manufacturer"] for engine in engines])
+
+    def test_ungrouped_retro_entries_have_empty_manufacturer(self):
+        engines = self._read(
+            "retro.ini",
+            ENGINE_SECTION.format(section="mame/one", name="One")
+            + "; Manufacturer: Novag\n"
+            + ENGINE_SECTION.format(section="mame/two", name="Two"),
+        )
+        self.assertEqual(["", "Novag"], [engine["manufacturer"] for engine in engines])
+
+    def test_manufacturer_directive_is_ignored_outside_retro_ini(self):
+        engines = self._read(
+            "engines.ini",
+            "; Manufacturer: Mephisto\n" + ENGINE_SECTION.format(section="one", name="One"),
+        )
+        self.assertNotIn("manufacturer", engines[0])

--- a/tests/uci/test_read.py
+++ b/tests/uci/test_read.py
@@ -38,7 +38,7 @@ class TestReadEngineIniManufacturer(unittest.TestCase):
             "retro.ini",
             "; Manufacturer: Mephisto\n"
             + ENGINE_SECTION.format(section="mame/one", name="One")
-            + "; ordinary comment\n;Manufacturer: Novag\n; manufacturer: Novag\n"
+            + "; ordinary comment\n;Manufacturer: Novag\n; manufacturer: Novag\n; Manufacturer:   \n"
             + ENGINE_SECTION.format(section="mame/two", name="Two"),
         )
         self.assertEqual(["Mephisto", "Mephisto"], [engine["manufacturer"] for engine in engines])

--- a/tests/uci/test_read.py
+++ b/tests/uci/test_read.py
@@ -43,7 +43,7 @@ class TestReadEngineIniManufacturer(unittest.TestCase):
         )
         self.assertEqual(["Mephisto", "Mephisto"], [engine["manufacturer"] for engine in engines])
 
-    def test_ungrouped_retro_entries_have_empty_manufacturer(self):
+    def test_ungrouped_entries_have_empty_manufacturer(self):
         engines = self._read(
             "retro.ini",
             ENGINE_SECTION.format(section="mame/one", name="One")
@@ -52,9 +52,16 @@ class TestReadEngineIniManufacturer(unittest.TestCase):
         )
         self.assertEqual(["", "Novag"], [engine["manufacturer"] for engine in engines])
 
-    def test_manufacturer_directive_is_ignored_outside_retro_ini(self):
+    def test_manufacturer_directive_applies_to_every_engine_ini(self):
         engines = self._read(
             "engines.ini",
             "; Manufacturer: Mephisto\n" + ENGINE_SECTION.format(section="one", name="One"),
         )
-        self.assertNotIn("manufacturer", engines[0])
+        self.assertEqual("Mephisto", engines[0]["manufacturer"])
+
+    def test_future_engine_ini_without_directives_keeps_empty_metadata(self):
+        engines = self._read(
+            "community.ini",
+            ENGINE_SECTION.format(section="one", name="One"),
+        )
+        self.assertEqual("", engines[0]["manufacturer"])

--- a/uci/engine_provider.py
+++ b/uci/engine_provider.py
@@ -51,17 +51,22 @@ class EngineProvider(object):
     @classmethod
     def get_retro_groups(cls) -> List[Dict]:
         """Return manufacturer groups containing stable indexes into retro_engines."""
-        if not any(str(engine.get("manufacturer", "")).strip() for engine in cls.retro_engines):
+        return cls.get_engine_groups(cls.retro_engines)
+
+    @classmethod
+    def get_engine_groups(cls, engines: List[Dict]) -> List[Dict]:
+        """Return optional manufacturer groups for any engine catalog."""
+        if not any(str(engine.get("manufacturer", "")).strip() for engine in engines):
             return []
 
         groups = OrderedDict()
-        for index, engine in enumerate(cls.retro_engines):
+        for index, engine in enumerate(engines):
             manufacturer = str(engine.get("manufacturer", "")).strip() or "Other"
             groups.setdefault(manufacturer, []).append(index)
 
         if cls.engine_menu_sort in ("engine", "manufacturer"):
             for indexes in groups.values():
-                indexes.sort(key=lambda item: (str(cls.retro_engines[item].get("name", "")).casefold(), item))
+                indexes.sort(key=lambda item: (str(engines[item].get("name", "")).casefold(), item))
 
         group_items = list(groups.items())
         if cls.engine_menu_sort == "manufacturer":
@@ -71,9 +76,14 @@ class EngineProvider(object):
     @classmethod
     def get_flat_retro_engine_indexes(cls) -> List[int]:
         """Return the presentation order used when retro.ini has no manufacturer metadata."""
-        indexes = list(range(len(cls.retro_engines)))
+        return cls.get_flat_engine_indexes(cls.retro_engines)
+
+    @classmethod
+    def get_flat_engine_indexes(cls, engines: List[Dict]) -> List[int]:
+        """Return flat presentation indexes for an engine catalog."""
+        indexes = list(range(len(engines)))
         if cls.engine_menu_sort in ("engine", "manufacturer"):
-            indexes.sort(key=lambda item: (str(cls.retro_engines[item].get("name", "")).casefold(), item))
+            indexes.sort(key=lambda item: (str(engines[item].get("name", "")).casefold(), item))
         return indexes
 
     @staticmethod

--- a/uci/engine_provider.py
+++ b/uci/engine_provider.py
@@ -68,6 +68,14 @@ class EngineProvider(object):
             group_items.sort(key=lambda item: item[0].casefold())
         return [{"manufacturer": manufacturer, "engine_indexes": indexes} for manufacturer, indexes in group_items]
 
+    @classmethod
+    def get_flat_retro_engine_indexes(cls) -> List[int]:
+        """Return the presentation order used when retro.ini has no manufacturer metadata."""
+        indexes = list(range(len(cls.retro_engines)))
+        if cls.engine_menu_sort in ("engine", "manufacturer"):
+            indexes.sort(key=lambda item: (str(cls.retro_engines[item].get("name", "")).casefold(), item))
+        return indexes
+
     @staticmethod
     def engine_matches(installed_file: str, requested_file: Optional[str]) -> bool:
         """Return True when a configured engine path resolves to an installed engine entry."""

--- a/uci/engine_provider.py
+++ b/uci/engine_provider.py
@@ -11,6 +11,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+from collections import OrderedDict
 from typing import Dict, List, Optional
 
 from uci.read import read_engine_ini
@@ -25,9 +26,11 @@ class EngineProvider(object):
     retro_engines: List[Dict[str, str]] = []
     favorite_engines: List[Dict[str, str]] = []
     installed_engines: List[Dict[str, str]] = []
+    engine_menu_sort = "file"
 
     @classmethod
-    def init(cls):
+    def init(cls, engine_menu_sort: str = "file"):
+        cls.set_engine_menu_sort(engine_menu_sort)
         cls.modern_engines: List[Dict[str, str]] = read_engine_ini(filename="engines.ini")
         cls.retro_engines: List[Dict[str, str]] = read_engine_ini(filename="retro.ini")
         cls.favorite_engines: List[Dict[str, str]] = read_engine_ini(filename="favorites.ini")
@@ -37,6 +40,33 @@ class EngineProvider(object):
         if not cls.favorite_engines:
             cls.favorite_engines = cls.modern_engines
         cls.installed_engines: List[Dict[str, str]] = cls.modern_engines + cls.retro_engines + cls.favorite_engines
+
+    @classmethod
+    def set_engine_menu_sort(cls, sort_order: str) -> str:
+        """Set presentation ordering without changing any engine-list indexes."""
+        normalized = str(sort_order or "file").strip().lower()
+        cls.engine_menu_sort = normalized if normalized in ("file", "engine", "manufacturer") else "file"
+        return cls.engine_menu_sort
+
+    @classmethod
+    def get_retro_groups(cls) -> List[Dict]:
+        """Return manufacturer groups containing stable indexes into retro_engines."""
+        if not any(str(engine.get("manufacturer", "")).strip() for engine in cls.retro_engines):
+            return []
+
+        groups = OrderedDict()
+        for index, engine in enumerate(cls.retro_engines):
+            manufacturer = str(engine.get("manufacturer", "")).strip() or "Other"
+            groups.setdefault(manufacturer, []).append(index)
+
+        if cls.engine_menu_sort in ("engine", "manufacturer"):
+            for indexes in groups.values():
+                indexes.sort(key=lambda item: (str(cls.retro_engines[item].get("name", "")).casefold(), item))
+
+        group_items = list(groups.items())
+        if cls.engine_menu_sort == "manufacturer":
+            group_items.sort(key=lambda item: item[0].casefold())
+        return [{"manufacturer": manufacturer, "engine_indexes": indexes} for manufacturer, indexes in group_items]
 
     @staticmethod
     def engine_matches(installed_file: str, requested_file: Optional[str]) -> bool:

--- a/uci/read.py
+++ b/uci/read.py
@@ -36,7 +36,7 @@ def _retro_manufacturers(lines) -> dict[str, str]:
     for raw_line in lines:
         line = raw_line.rstrip("\r\n")
         directive = _RETRO_MANUFACTURER_RE.match(line)
-        if directive:
+        if directive and directive.group(1).strip():
             current_manufacturer = directive.group(1).strip()
             continue
         section = _INI_SECTION_RE.match(line)

--- a/uci/read.py
+++ b/uci/read.py
@@ -19,10 +19,30 @@ import logging
 import platform
 import configparser
 import os
+import re
 from dgt.api import Dgt
 
 
 logger = logging.getLogger(__name__)
+
+_RETRO_MANUFACTURER_RE = re.compile(r"^; Manufacturer: (.+?)\s*$")
+_INI_SECTION_RE = re.compile(r"^\s*\[([^\]]+)\]\s*$")
+
+
+def _retro_manufacturers(lines) -> dict[str, str]:
+    """Map retro.ini sections to the active strict manufacturer directive."""
+    manufacturers = {}
+    current_manufacturer = ""
+    for raw_line in lines:
+        line = raw_line.rstrip("\r\n")
+        directive = _RETRO_MANUFACTURER_RE.match(line)
+        if directive:
+            current_manufacturer = directive.group(1).strip()
+            continue
+        section = _INI_SECTION_RE.match(line)
+        if section:
+            manufacturers[section.group(1).strip()] = current_manufacturer
+    return manufacturers
 
 
 def read_engine_ini(engine_shell=None, engine_path=None, filename=None) -> list[dict[str, str]]:
@@ -32,17 +52,26 @@ def read_engine_ini(engine_shell=None, engine_path=None, filename=None) -> list[
         filename = "engines.ini"
     config = configparser.ConfigParser()
     config.optionxform = str  # type: ignore
+    manufacturers = {}
     try:
         if engine_shell is None:
             if not engine_path:
                 program_path = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
                 engine_path = program_path + os.sep + "engines" + os.sep + platform.machine()
             logger.debug("complete path without shell: %s", str(engine_path + os.sep + filename))
+            if filename == "retro.ini":
+                with open(engine_path + os.sep + filename, "r", encoding="utf-8") as file:
+                    manufacturers = _retro_manufacturers(file)
             config.read(engine_path + os.sep + filename)
         else:
             logger.debug("complete path: %s", str(engine_path + os.sep + filename))
             with engine_shell.open(engine_path + os.sep + filename, "r") as file:
-                config.read_file(file)
+                if filename == "retro.ini":
+                    lines = file.readlines()
+                    manufacturers = _retro_manufacturers(lines)
+                    config.read_string("".join(lines))
+                else:
+                    config.read_file(file)
     except FileNotFoundError:
         pass
 
@@ -79,13 +108,14 @@ def read_engine_ini(engine_shell=None, engine_path=None, filename=None) -> list[
             maxtime=0,
             devs={"ser", "i2c", "web"},
         )
-        library.append(
-            {
-                "file": engine_path + os.sep + section,
-                "level_dict": level_dict,
-                "text": text,
-                "name": confsect["name"],
-                "elo": confsect["elo"],
-            }
-        )
+        engine = {
+            "file": engine_path + os.sep + section,
+            "level_dict": level_dict,
+            "text": text,
+            "name": confsect["name"],
+            "elo": confsect["elo"],
+        }
+        if filename == "retro.ini":
+            engine["manufacturer"] = manufacturers.get(section, "")
+        library.append(engine)
     return library

--- a/uci/read.py
+++ b/uci/read.py
@@ -69,7 +69,7 @@ def read_engine_ini(engine_shell=None, engine_path=None, filename=None) -> list[
                 lines = file.readlines()
                 manufacturers = _engine_manufacturers(lines)
                 config.read_string("".join(lines))
-    except FileNotFoundError:
+    except OSError:
         pass
 
     library = []

--- a/uci/read.py
+++ b/uci/read.py
@@ -25,17 +25,17 @@ from dgt.api import Dgt
 
 logger = logging.getLogger(__name__)
 
-_RETRO_MANUFACTURER_RE = re.compile(r"^; Manufacturer: (.+?)\s*$")
+_ENGINE_MANUFACTURER_RE = re.compile(r"^; Manufacturer: (.+?)\s*$")
 _INI_SECTION_RE = re.compile(r"^\s*\[([^\]]+)\]\s*$")
 
 
-def _retro_manufacturers(lines) -> dict[str, str]:
-    """Map retro.ini sections to the active strict manufacturer directive."""
+def _engine_manufacturers(lines) -> dict[str, str]:
+    """Map engine INI sections to the active strict manufacturer directive."""
     manufacturers = {}
     current_manufacturer = ""
     for raw_line in lines:
         line = raw_line.rstrip("\r\n")
-        directive = _RETRO_MANUFACTURER_RE.match(line)
+        directive = _ENGINE_MANUFACTURER_RE.match(line)
         if directive and directive.group(1).strip():
             current_manufacturer = directive.group(1).strip()
             continue
@@ -59,19 +59,16 @@ def read_engine_ini(engine_shell=None, engine_path=None, filename=None) -> list[
                 program_path = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
                 engine_path = program_path + os.sep + "engines" + os.sep + platform.machine()
             logger.debug("complete path without shell: %s", str(engine_path + os.sep + filename))
-            if filename == "retro.ini":
-                with open(engine_path + os.sep + filename, "r", encoding="utf-8") as file:
-                    manufacturers = _retro_manufacturers(file)
-            config.read(engine_path + os.sep + filename)
+            with open(engine_path + os.sep + filename, "r", encoding="utf-8") as file:
+                lines = file.readlines()
+            manufacturers = _engine_manufacturers(lines)
+            config.read_string("".join(lines))
         else:
             logger.debug("complete path: %s", str(engine_path + os.sep + filename))
             with engine_shell.open(engine_path + os.sep + filename, "r") as file:
-                if filename == "retro.ini":
-                    lines = file.readlines()
-                    manufacturers = _retro_manufacturers(lines)
-                    config.read_string("".join(lines))
-                else:
-                    config.read_file(file)
+                lines = file.readlines()
+                manufacturers = _engine_manufacturers(lines)
+                config.read_string("".join(lines))
     except FileNotFoundError:
         pass
 
@@ -115,7 +112,6 @@ def read_engine_ini(engine_shell=None, engine_path=None, filename=None) -> list[
             "name": confsect["name"],
             "elo": confsect["elo"],
         }
-        if filename == "retro.ini":
-            engine["manufacturer"] = manufacturers.get(section, "")
+        engine["manufacturer"] = manufacturers.get(section, "")
         library.append(engine)
     return library

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -79,6 +79,16 @@ explicitly requires it.
   settings overlay. Its Back control closes the picker and returns visually to
   the BOOK tab; it must not lead into the main settings menu.
 
+## Engine Manufacturer Metadata
+
+- Parse strict `; Manufacturer: ...` directives in every engine INI catalog,
+  including `engines.ini`, `retro.ini`, `favorites.ini`, and future catalogs.
+- Each engine category independently enables its manufacturer level when at
+  least one entry has metadata. Missing metadata in a grouped category belongs
+  to `Other`.
+- If a category has no manufacturer metadata, preserve the previous flat list.
+  Under engine or manufacturer sorting, that fallback list is alphabetical.
+
 ## Game Lifecycle State
 
 - `game_started` is a lifecycle flag for the web client and CPU-saving analysis

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -69,6 +69,12 @@ explicitly requires it.
 - The old `BOOK` tab changes only the opening information shown to the human in
   the web client. It must keep the special `ObookSrv` index 0 entry.
 - Do not let the old `BOOK` tab change the playing engine book.
+- Present both web book pickers alphabetically by their visible labels. Keep
+  the web-only `ObookSrv` entry pinned first in the `BOOK`-tab picker.
+- The `BOOK` tab uses one compact selector that opens its own modern picker;
+  do not restore slow previous/next book cycling. Its selection remains
+  browser-specific and must use the web-book action rather than the Engine Book
+  action.
 
 ## Game Lifecycle State
 

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -75,6 +75,9 @@ explicitly requires it.
   do not restore slow previous/next book cycling. Its selection remains
   browser-specific and must use the web-book action rather than the Engine Book
   action.
+- Treat the `BOOK`-tab picker as standalone rather than as a submenu of the
+  settings overlay. Its Back control closes the picker and returns visually to
+  the BOOK tab; it must not lead into the main settings menu.
 
 ## Game Lifecycle State
 

--- a/web/picoweb/static/js/app.js
+++ b/web/picoweb/static/js/app.js
@@ -335,7 +335,7 @@ var dataTableFen = START_FEN;
 
 // web-specific opening book selection (independent from engine)
 var webBookList = [];
-var webBookStorageKey = 'webBookIndexV2';
+var webBookStorageKey = 'webBookIndexV3';
 var currentWebBookIndex = parseInt(localStorage.getItem(webBookStorageKey)) || 0;
 var chessGameType = 0; // 0=Standard ; 1=Chess960
 var computerside = ""; // color played by the computer
@@ -463,12 +463,12 @@ function loadWebBookList() {
     });
 }
 
-function changeWebBook(delta) {
+function selectWebBook(index) {
     if (!webBookList.length) { return; }
-    var nextIndex = (currentWebBookIndex + delta + webBookList.length) % webBookList.length;
+    var nextIndex = Math.max(0, Math.min(parseInt(index, 10) || 0, webBookList.length - 1));
     currentWebBookIndex = nextIndex;
     localStorage.setItem(webBookStorageKey, currentWebBookIndex);
-    $.getJSON('/book',
+    return $.getJSON('/book',
         { action: 'set_book_index', index: nextIndex },
         function (data) {
             if (data && data.book) {
@@ -3703,8 +3703,12 @@ $(function () {
 
     $.fn.dataTable.ext.errMode = 'throw';
 
-    $('#bookPrev').on('click', function () { changeWebBook(-1); });
-    $('#bookNext').on('click', function () { changeWebBook(1); });
+    $('#bookSelect').on('click', function () {
+        if (window.picoOverlay) {
+            window.picoOverlay.open();
+            window.picoOverlay.showWebBook();
+        }
+    });
 
     // Static bindings for persistent SHOW/HIDE and ± buttons.
     $('#engineToggleBtn').on('click', function () {

--- a/web/picoweb/templates/clock.html
+++ b/web/picoweb/templates/clock.html
@@ -423,14 +423,15 @@
         }
 
         .book-header-row {
-            display: grid;
-            grid-template-columns: minmax(0, 1fr) 2rem;
+            display: flex;
             align-items: center;
+            justify-content: center;
             gap: 0.5rem;
             width: 100%;
         }
 
         .book-title {
+            flex: 0 1 auto;
             min-width: 0;
             overflow: hidden;
             text-overflow: ellipsis;
@@ -3685,6 +3686,10 @@
                     goBack();
                     return;
                 }
+                if (e.target.closest('#ovl-web-book-back')) {
+                    close();
+                    return;
+                }
 
                 if (e.target.closest('.pico-overlay-back')) { goBack(); return; }
                 if (e.target.closest('#backToMenuBtn')) { goBack(); return; }
@@ -3805,7 +3810,12 @@
                 showMode: function() { navigateTo(showMode); },
                 showTime: function() { navigateTo(showTime); },
                 showBook: function() { navigateTo(showEngineBook); },
-                showWebBook: function() { navigateTo(showWebBook); },
+                showWebBook: function() {
+                    navStack = [];
+                    showWebBook();
+                    currentView = showWebBook;
+                    updateOverlayBack();
+                },
                 showTutor: function() { navigateTo(showTutor); },
                 showPosition: function() { navigateTo(showPosition); },
                 showGame: function() { navigateTo(showGame); },
@@ -4244,7 +4254,7 @@
             <!-- WEB BOOK EXPLORER SUB-PANEL -->
             <div id="overlay-web-book" class="pico-subpanel">
                 <div class="pico-picker-header">
-                    <button class="pico-overlay-back">‹ Back</button>
+                    <button class="pico-overlay-back" id="ovl-web-book-back">‹ Back</button>
                     <span class="pico-picker-title">Book Explorer</span>
                 </div>
                 <div class="pico-picker-col" style="flex:1; overflow-y:auto;">

--- a/web/picoweb/templates/clock.html
+++ b/web/picoweb/templates/clock.html
@@ -2303,8 +2303,8 @@
                         _engAllData = data.engines || [];
                         setCurrentSetting('engine_menu_sort', data.engine_menu_sort || 'file');
                         if (!_engAllData.length) { listEl.innerHTML = '<div style="opacity:0.5;font-size:0.8rem;padding:0.3rem;">No engines found</div>'; return; }
-                        var hasManufacturers = cat === 'retro' && _engAllData.some(function(eng) {
-                            return (eng.category || '') === 'retro' && Boolean(eng.manufacturer);
+                        var hasManufacturers = _engAllData.some(function(eng) {
+                            return (eng.category || '') === cat && Boolean(eng.manufacturer);
                         });
                         if (hasManufacturers) {
                             _showManufacturerList(cat);
@@ -2516,7 +2516,8 @@
                 levelEl.style.display = 'none';
                 document.getElementById('ovl-level-list').innerHTML = '';
                 listEl.innerHTML = '';
-                setOverlayPath('Engine > Retro > Manufacturer');
+                var catDef = _engCatDefs.find(function(d) { return d.value === cat; }) || { label: cat };
+                setOverlayPath('Engine > ' + catDef.label + ' > Manufacturer');
                 var manufacturers = [];
                 _engAllData.forEach(function(eng) {
                     if ((eng.category || '') !== cat || !eng.manufacturer) return;
@@ -2546,7 +2547,10 @@
                 levelEl.style.display = 'none';
                 document.getElementById('ovl-level-list').innerHTML = '';
                 listEl.innerHTML = '';
-                if (manufacturer) setOverlayPath('Engine > Retro > ' + manufacturer);
+                if (manufacturer) {
+                    var catDef = _engCatDefs.find(function(d) { return d.value === cat; }) || { label: cat };
+                    setOverlayPath('Engine > ' + catDef.label + ' > ' + manufacturer);
+                }
                 var filtered = _engAllData.filter(function(e) {
                     var categoryMatches = !cat || cat === 'all' || (e.category || 'modern') === cat;
                     return categoryMatches && (!manufacturer || e.manufacturer === manufacturer);

--- a/web/picoweb/templates/clock.html
+++ b/web/picoweb/templates/clock.html
@@ -424,7 +424,7 @@
 
         .book-header-row {
             display: grid;
-            grid-template-columns: 2rem minmax(0, 1fr) 2rem;
+            grid-template-columns: minmax(0, 1fr) 2rem;
             align-items: center;
             gap: 0.5rem;
             width: 100%;
@@ -781,19 +781,14 @@
                                                 <div id="currentBookContainer" class="mb-2 d-none">
                                                     <div class="alert alert-secondary py-1 px-2 text-center mb-2">
                                                         <div class="book-header-row">
-                                                            <button type="button" id="bookPrev"
-                                                                class="btn btn-sm btn-primary book-switch-btn"
-                                                                aria-label="Previous opening book" title="Previous book">
-                                                                <i class="fa fa-chevron-left" aria-hidden="true"></i>
-                                                            </button>
                                                             <span class="book-title">
                                                                 <span class="fw-bold">Book:&nbsp;</span>
                                                                 <span id="currentBookName">No book</span>
                                                             </span>
-                                                            <button type="button" id="bookNext"
+                                                            <button type="button" id="bookSelect"
                                                                 class="btn btn-sm btn-primary book-switch-btn"
-                                                                aria-label="Next opening book" title="Next book">
-                                                                <i class="fa fa-chevron-right" aria-hidden="true"></i>
+                                                                aria-label="Select opening book" title="Select opening book">
+                                                                <i class="fa fa-chevron-down" aria-hidden="true"></i>
                                                             </button>
                                                         </div>
                                                     </div>
@@ -1142,6 +1137,7 @@
                 'overlay-time': 'Time',
                 'overlay-engine': 'Engine',
                 'overlay-book': 'Engine Book',
+                'overlay-web-book': 'Book Explorer',
                 'overlay-tutor': 'Tutor',
                 'overlay-position': 'Position',
                 'overlay-game': 'Game',
@@ -2468,6 +2464,48 @@
                     .catch(function() { listEl.innerHTML = '<div style="opacity:0.5;font-size:0.8rem;padding:0.3rem;">Failed to load</div>'; });
             }
 
+            function showWebBook() {
+                showSubpanel('overlay-web-book');
+                var listEl = document.getElementById('ovl-web-book-list');
+                listEl.innerHTML = '<div style="opacity:0.5;font-size:0.8rem;padding:0.3rem;">Loading…</div>';
+                fetch('/book?action=get_book_list')
+                    .then(function(r) { return r.json(); })
+                    .then(function(data) {
+                        listEl.innerHTML = '';
+                        webBookList = data.books || [];
+                        var storedIndex = parseInt(localStorage.getItem(webBookStorageKey), 10);
+                        if (Number.isFinite(storedIndex) && storedIndex >= 0 && storedIndex < webBookList.length) {
+                            currentWebBookIndex = storedIndex;
+                        } else if (typeof data.current_index === 'number') {
+                            currentWebBookIndex = data.current_index;
+                        } else {
+                            currentWebBookIndex = 0;
+                        }
+                        webBookList.forEach(function(book) {
+                            var btn = document.createElement('button');
+                            btn.className = 'pico-picker-item';
+                            btn.classList.toggle('selected', book.index === currentWebBookIndex);
+                            var label = book.label || book.file || ('Book ' + (book.index + 1));
+                            var nameEl = document.createElement('strong');
+                            nameEl.textContent = label;
+                            btn.appendChild(nameEl);
+                            btn.addEventListener('click', function() {
+                                listEl.querySelectorAll('.pico-picker-item').forEach(function(el) {
+                                    el.classList.remove('selected');
+                                });
+                                btn.classList.add('selected');
+                                selectWebBook(book.index);
+                                setTimeout(close, 180);
+                            });
+                            listEl.appendChild(btn);
+                        });
+                        if (!webBookList.length) {
+                            listEl.innerHTML = '<div style="opacity:0.5;font-size:0.8rem;padding:0.3rem;">No books found</div>';
+                        }
+                    })
+                    .catch(function() { listEl.innerHTML = '<div style="opacity:0.5;font-size:0.8rem;padding:0.3rem;">Failed to load</div>'; });
+            }
+
             /* ── engine category filter ──────────────── */
             var _engCurrentCat = 'modern';
             var _engAllData    = [];
@@ -3767,6 +3805,7 @@
                 showMode: function() { navigateTo(showMode); },
                 showTime: function() { navigateTo(showTime); },
                 showBook: function() { navigateTo(showEngineBook); },
+                showWebBook: function() { navigateTo(showWebBook); },
                 showTutor: function() { navigateTo(showTutor); },
                 showPosition: function() { navigateTo(showPosition); },
                 showGame: function() { navigateTo(showGame); },
@@ -4201,6 +4240,18 @@
                     <div id="ovl-book-list"><div style="opacity:0.5;font-size:0.8rem;padding:0.3rem;">Loading…</div></div>
                 </div>
             </div><!-- #overlay-book -->
+
+            <!-- WEB BOOK EXPLORER SUB-PANEL -->
+            <div id="overlay-web-book" class="pico-subpanel">
+                <div class="pico-picker-header">
+                    <button class="pico-overlay-back">‹ Back</button>
+                    <span class="pico-picker-title">Book Explorer</span>
+                </div>
+                <div class="pico-picker-col" style="flex:1; overflow-y:auto;">
+                    <div class="pico-picker-col-label">Select Display Book</div>
+                    <div id="ovl-web-book-list"><div style="opacity:0.5;font-size:0.8rem;padding:0.3rem;">Loading…</div></div>
+                </div>
+            </div><!-- #overlay-web-book -->
 
             <!-- TUTOR SUB-PANEL -->
             <div id="overlay-tutor" class="pico-subpanel">

--- a/web/picoweb/templates/clock.html
+++ b/web/picoweb/templates/clock.html
@@ -2206,7 +2206,8 @@
             var _engCatDefs = [
                 { icon: '💻', label: 'Modern',    value: 'modern'    },
                 { icon: '🕰️', label: 'Retro',     value: 'retro'     },
-                { icon: '⭐',  label: 'Favorites', value: 'favorites' }
+                { icon: '⭐',  label: 'Favorites', value: 'favorites' },
+                { icon: '↕️', label: 'Sort Order', value: 'sort'      }
             ];
 
             function renderEngineCatTiles() {
@@ -2221,14 +2222,62 @@
                     var lEl = document.createElement('span'); lEl.className = 'pico-tile-label';
                     lEl.textContent = cat.icon + ' ' + cat.label;
                     btn.appendChild(lEl);
-                    btn.addEventListener('click', function() { navigateTo(function() { openEngineCat(cat.value); }); });
+                    if (cat.value === 'sort') {
+                        var sortLabels = {file:'File order', engine:'Engine name', manufacturer:'Manufacturer'};
+                        var sortValue = (window._picoCurrentSettings || {}).engine_menu_sort || 'file';
+                        var sEl = document.createElement('span'); sEl.className = 'pico-tile-sub';
+                        sEl.textContent = sortLabels[sortValue] || sortLabels.file;
+                        btn.appendChild(sEl);
+                    }
+                    btn.addEventListener('click', function() {
+                        if (cat.value === 'sort') {
+                            navigateTo(showEngineSort);
+                        } else {
+                            navigateTo(function() { openEngineCat(cat.value); });
+                        }
+                    });
                     grid.appendChild(btn);
                 });
-                for (var i = 0; i < 6; i++) {
+                for (var i = _engCatDefs.length; i < 9; i++) {
                     var e = document.createElement('button'); e.className = 'pico-tile pico-empty-tile';
                     e.setAttribute('aria-hidden','true'); e.tabIndex = -1; grid.appendChild(e);
                 }
                 gridEl.appendChild(grid);
+            }
+
+            function showEngineSort() {
+                setOverlayPath('Engine > Sort Order');
+                document.getElementById('ovl-engine-cat-grid').style.display = 'none';
+                document.getElementById('ovl-engine-cat-back').style.display = '';
+                var lbl = document.getElementById('ovl-engine-sub-label');
+                lbl.style.display = '';
+                lbl.textContent = '↕️ Sort Order';
+                document.getElementById('ovl-engine-sub-panel').style.display = 'flex';
+                document.getElementById('ovl-level-col').style.display = 'none';
+                var listEl = document.getElementById('ovl-engine-list');
+                listEl.innerHTML = '';
+                var current = (window._picoCurrentSettings || {}).engine_menu_sort || 'file';
+                [
+                    {value:'file', label:'File order'},
+                    {value:'engine', label:'Engine name'},
+                    {value:'manufacturer', label:'Manufacturer'}
+                ].forEach(function(option) {
+                    var btn = document.createElement('button');
+                    btn.className = 'pico-picker-item' + (option.value === current ? ' selected' : '');
+                    var nameEl = document.createElement('strong');
+                    nameEl.textContent = option.label;
+                    btn.appendChild(nameEl);
+                    btn.addEventListener('click', function() {
+                        listEl.querySelectorAll('.pico-picker-item').forEach(function(el) {
+                            el.classList.remove('selected');
+                        });
+                        btn.classList.add('selected');
+                        setCurrentSetting('engine_menu_sort', option.value);
+                        post('action=engine_menu_sort&val=' + encodeURIComponent(option.value));
+                        setTimeout(goBack, 180);
+                    });
+                    listEl.appendChild(btn);
+                });
             }
 
             function openEngineCat(cat) {
@@ -2255,8 +2304,16 @@
                     .then(function(r) { return r.json(); })
                     .then(function(data) {
                         _engAllData = data.engines || [];
+                        setCurrentSetting('engine_menu_sort', data.engine_menu_sort || 'file');
                         if (!_engAllData.length) { listEl.innerHTML = '<div style="opacity:0.5;font-size:0.8rem;padding:0.3rem;">No engines found</div>'; return; }
-                        _showEngineList(cat);
+                        var hasManufacturers = cat === 'retro' && _engAllData.some(function(eng) {
+                            return (eng.category || '') === 'retro' && Boolean(eng.manufacturer);
+                        });
+                        if (hasManufacturers) {
+                            _showManufacturerList(cat);
+                        } else {
+                            _showEngineList(cat);
+                        }
                     })
                     .catch(function() { listEl.innerHTML = '<div style="opacity:0.5;font-size:0.8rem;padding:0.3rem;">Failed to load</div>'; });
             }
@@ -2268,6 +2325,13 @@
                 document.getElementById('ovl-engine-sub-label').style.display = 'none';
                 document.getElementById('ovl-engine-cat-grid').style.display = '';
                 renderEngineCatTiles();
+                fetch('/info?action=get_current_settings')
+                    .then(function(r) { return r.json(); })
+                    .then(function(d) {
+                        window._picoCurrentSettings = d;
+                        renderEngineCatTiles();
+                    })
+                    .catch(function() {});
             }
 
             function populateLevels(file, levels) {
@@ -2407,13 +2471,47 @@
             /* ── engine category filter ──────────────── */
             var _engCurrentCat = 'modern';
             var _engAllData    = [];
-            function _showEngineList(cat) {
+            function _showManufacturerList(cat) {
+                var listEl = document.getElementById('ovl-engine-list');
+                var levelEl = document.getElementById('ovl-level-col');
+                levelEl.style.display = 'none';
+                document.getElementById('ovl-level-list').innerHTML = '';
+                listEl.innerHTML = '';
+                setOverlayPath('Engine > Retro > Manufacturer');
+                var manufacturers = [];
+                _engAllData.forEach(function(eng) {
+                    if ((eng.category || '') !== cat || !eng.manufacturer) return;
+                    if (manufacturers.indexOf(eng.manufacturer) === -1) manufacturers.push(eng.manufacturer);
+                });
+                var currentEngine = (window._picoSystemInfo && window._picoSystemInfo.engine_name) || '';
+                manufacturers.forEach(function(manufacturer) {
+                    var btn = document.createElement('button');
+                    var containsCurrent = _engAllData.some(function(eng) {
+                        return eng.category === cat && eng.manufacturer === manufacturer
+                            && (eng.name || eng.file) === currentEngine;
+                    });
+                    btn.className = 'pico-picker-item' + (containsCurrent ? ' selected' : '');
+                    var nameEl = document.createElement('strong');
+                    nameEl.textContent = manufacturer;
+                    btn.appendChild(nameEl);
+                    btn.addEventListener('click', function() {
+                        navigateTo(function() { _showEngineList(cat, manufacturer); });
+                    });
+                    listEl.appendChild(btn);
+                });
+            }
+
+            function _showEngineList(cat, manufacturer) {
                 var listEl  = document.getElementById('ovl-engine-list');
                 var levelEl = document.getElementById('ovl-level-col');
                 levelEl.style.display = 'none';
                 document.getElementById('ovl-level-list').innerHTML = '';
                 listEl.innerHTML = '';
-                var filtered = _engAllData.filter(function(e) { return !cat || cat === 'all' || (e.category || 'modern') === cat; });
+                if (manufacturer) setOverlayPath('Engine > Retro > ' + manufacturer);
+                var filtered = _engAllData.filter(function(e) {
+                    var categoryMatches = !cat || cat === 'all' || (e.category || 'modern') === cat;
+                    return categoryMatches && (!manufacturer || e.manufacturer === manufacturer);
+                });
                 if (!filtered.length) { listEl.innerHTML = '<div style="opacity:0.5;font-size:0.8rem;padding:0.3rem;">None</div>'; return; }
                 var _curEngineName = (window._picoSystemInfo && window._picoSystemInfo.engine_name) || '';
                 filtered.forEach(function(eng) {


### PR DESCRIPTION
**Summary**
Improves Retro engine selection for large engine collections.
Adds optional ; Manufacturer: <name> metadata support in retro.ini.

Adds a conditional manufacturer sub-menu:
Engine → Retro → Manufacturer → Engine → Level
Preserves the existing flat Retro menu when no manufacturer metadata exists.
Places ungrouped engines under Other only when a file contains manufacturer metadata.
Adds engine-menu-sort = file|engine|manufacturer.
Adds a Sort Order tile to the modernized web Engine menu.
Keeps engine loading, engine indexes, and analysis behavior unchanged.

**Sorting**
file: preserve retro.ini order.
engine: alphabetical engine names.
manufacturer: alphabetical manufacturers, then engine names.
Sorting is presentation-only; it does not reorder Picochess underlying engine catalog or alter the selected engine.

**Testing**
venv/bin/tox -e unit passes: 318 tests.
Inline web-menu JavaScript syntax check passes.